### PR TITLE
Update new_registry_dialog.gd

### DIFF
--- a/addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+++ b/addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
@@ -318,8 +318,7 @@ func _on_class_list_dialog_button_pressed() -> void:
 func _on_class_list_dialog_confirmed(type_name: StringName) -> void:
 	exclusive = true
 	if type_name:
-		var type_nameFile = type_name.get_basename().get_file()
-		class_restriction_line_edit.text = type_nameFile
+		class_restriction_line_edit.text = "\"" + type_name + "\""
 		_validate_fields()
 
 


### PR DESCRIPTION
Updated to strip filename on return to window.  Issue: [https://github.com/elliotfontaine/yard-godot/issues/10](https://github.com/elliotfontaine/yard-godot/issues/10)

Tested on Mono Godot with C# and GDScript resource. Also built in normal resource selection.

_**Needs tested on non-mono Godot.**_