### PR TITLE
feat: inform users that script paths in class restriction must be quoted

### DIFF
--- a/addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+++ b/addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
@@ -18,7 +18,7 @@ const ERROR_COLOR = Color(1, 0.47, 0.42)
 const INFO_MESSAGES: Dictionary[StringName, Array] = {
 	# --- Class restriction ---
 	&"class_valid": ["Class/script is a Resource subclass.", SUCCESS_COLOR],
-	&"class_invalid": ["Invalid class/script. Expected a Resource subclass (built-in, class_name, or script path).", ERROR_COLOR],
+	&"class_invalid": ["Invalid class/script. Expected a Resource subclass (built-in, class_name, or [u]quoted[/u] script path).", ERROR_COLOR],
 	&"class_empty": ["No class filter, all Resource files will be accepted to the registry.", WARNING_COLOR],
 
 	# --- Scan directory ---


### PR DESCRIPTION
<img width="458" height="312" alt="Capture d’écran 2026-03-04 à 13 16 44" src="https://github.com/user-attachments/assets/6ff2a2df-3cc8-418d-92ad-8ef5cb3baf09" />

Underlined _"quoted"_ in error message.
