### PR TITLE
fix: handle script path return from popup_create_dialog in Godot 4.6

### DIFF
--- a/addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+++ b/addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
@@ -315,11 +315,16 @@ func _on_class_list_dialog_button_pressed() -> void:
 	)
 
 
-func _on_class_list_dialog_confirmed(type_name: StringName) -> void:
+func _on_class_list_dialog_confirmed(type_name: String) -> void:
 	exclusive = true
-	if type_name:
-		class_restriction_line_edit.text = type_name
-		_validate_fields()
+	if not type_name:
+		return
+
+	if type_name.begins_with("res://") or type_name.begins_with("uid://"):
+		type_name = '"%s"' % type_name
+
+	class_restriction_line_edit.text = type_name
+	_validate_fields()
 
 
 func _on_class_filesystem_button_pressed() -> void:


### PR DESCRIPTION
Closes #10.

This was due to a change in Godot 4.6, for custom class scripts, `EditorInterface.popup_create_dialog` would return a path to the callback, even if the script had a `class_name` at the top.