### PR TITLE
fix: update resource picker base type handling for script-based class restrictions

### DIFF
--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -416,10 +416,14 @@ func _setup_add_entry() -> void:
 		_res_picker.queue_free()
 	_res_picker = EditorResourcePicker.new()
 	_res_picker.custom_minimum_size = Vector2(240, 0)
-	if current_registry._class_restriction:
-		_res_picker.base_type = current_registry._class_restriction
-	else:
+	var restriction := current_registry._class_restriction
+	if not restriction:
 		_res_picker.base_type = "Resource"
+	elif not RegistryIO.is_quoted_string(restriction):
+		_res_picker.base_type = restriction
+	else:
+		var script: Script = load(RegistryIO.unquote(restriction))
+		_res_picker.base_type = ClassUtils.get_type_name(script)
 	resource_picker_container.add_child(_res_picker)
 	_texture_rect_parent = _res_picker.get_child(0)
 	_res_picker.resource_changed.connect(_on_res_picker_resource_changed)


### PR DESCRIPTION
Closes #17

As `EditorResourcePicker.base_type` can only take a class name as value, this fix uses `ClassUtils.get_type_name(script)` when the class restriction is a script path.
`get_type_name` will return the closest class name in the script inheritance hierarchy.