### PR TITLE
feat: clarify unsaved resource error log with remediation steps

### DIFF
--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -684,7 +684,7 @@ func _on_add_entry_button_pressed() -> void:
 		update_view()
 	else:
 		print_rich(
-			"[color=%s]● [b]ERROR:[/b] Invalid Resource Error: are you sure it is saved as a file ?[/color]" % [
+			"[color=%s]● [b]ERROR:[/b] This resource is not saved as a file. Click [b]⌄[/b] then [b]Save[/b] on the resource picker to save it first.[/color]" % [
 				EditorThemeUtils.color_error.to_html(false),
 			],
 		)


### PR DESCRIPTION
Linked to #24, #17 and #1.

There was no bug, but users got confused.

The resource picker is mostly here for using it's "Quick Load" capabilities, but at the same time it allows creating a resource on the fly. So we should make sure people choosing this workflow aren't confused.