### PR TITLE
feat: warn when scan directory is set to project root

### DIFF
--- a/addons/yard/editor_only/locale/de_DE.po
+++ b/addons/yard/editor_only/locale/de_DE.po
@@ -94,6 +94,10 @@ msgid "Scan directory valid. Will watch for new Resources…"
 msgstr "Verzeichnis gültig. Neue Ressourcen werden automatisch erkannt…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "Das Scan-Verzeichnis ist auf den Projektstamm ([code]res://[/code]) gesetzt. Dies scannt das gesamte Projekt bei jedem Speichern und kann zu erheblichen Verlangsamungen im Editor führen."
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "Ungültiges Verzeichnis. Wählen Sie ein vorhandenes Verzeichnis."
 

--- a/addons/yard/editor_only/locale/en_US.po
+++ b/addons/yard/editor_only/locale/en_US.po
@@ -92,6 +92,10 @@ msgid "Scan directory valid. Will watch for new Resources…"
 msgstr "Scan directory valid. Will watch for new Resources…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "Scan directory invalid. Pick an existing directory."
 

--- a/addons/yard/editor_only/locale/es_ES.po
+++ b/addons/yard/editor_only/locale/es_ES.po
@@ -94,6 +94,10 @@ msgid "Scan directory valid. Will watch for new Resources…"
 msgstr "Directorio válido. Los nuevos recursos se detectarán automáticamente…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "El directorio de análisis está configurado como la raíz del proyecto ([code]res://[/code]). Esto analizará todo el proyecto en cada guardado de archivo, lo que puede causar una ralentización significativa del editor."
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "Directorio no válido. Elija un directorio existente."
 

--- a/addons/yard/editor_only/locale/fr_FR.po
+++ b/addons/yard/editor_only/locale/fr_FR.po
@@ -95,6 +95,10 @@ msgstr ""
 "Répertoire valide. Les nouvelles ressources seront détectées automatiquement…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "Le répertoire à analyser est défini sur la racine du projet ([code]res://[/code]). Cela analysera l'ensemble du projet à chaque sauvegarde, ce qui peut entraîner des ralentissements significatifs dans l'éditeur."
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "Répertoire invalide. Choisissez un répertoire existant."
 

--- a/addons/yard/editor_only/locale/it_IT.po
+++ b/addons/yard/editor_only/locale/it_IT.po
@@ -94,6 +94,10 @@ msgid "Scan directory valid. Will watch for new Resources…"
 msgstr "Directory valida. Le nuove risorse verranno rilevate automaticamente…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "La directory di scansione è impostata sulla radice del progetto ([code]res://[/code]). Questo analizzerà l'intero progetto ad ogni salvataggio, il che potrebbe causare un rallentamento significativo dell'editor."
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "Directory non valida. Scegli una directory esistente."
 

--- a/addons/yard/editor_only/locale/pl_PL.po
+++ b/addons/yard/editor_only/locale/pl_PL.po
@@ -93,6 +93,10 @@ msgid "Scan directory valid. Will watch for new Resources…"
 msgstr "Katalog prawidłowy. Nowe zasoby będą wykrywane automatycznie…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "Katalog skanowania jest ustawiony na katalog główny projektu ([code]res://[/code]). Spowoduje to skanowanie całego projektu przy każdym zapisie pliku, co może znacznie spowolnić edytor."
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "Nieprawidłowy katalog. Wybierz istniejący katalog."
 

--- a/addons/yard/editor_only/locale/plugin.pot
+++ b/addons/yard/editor_only/locale/plugin.pot
@@ -91,6 +91,10 @@ msgid "Scan directory valid. Will watch for new Resources…"
 msgstr ""
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr ""
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr ""
 

--- a/addons/yard/editor_only/locale/pt_BR.po
+++ b/addons/yard/editor_only/locale/pt_BR.po
@@ -93,6 +93,10 @@ msgid "Scan directory valid. Will watch for new Resources…"
 msgstr "Diretório válido. Novos recursos serão detectados automaticamente…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "O diretório de análise está definido como a raiz do projeto ([code]res://[/code]). Isso irá analisar o projeto inteiro a cada salvamento de arquivo, o que pode causar lentidão significativa no editor."
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "Diretório inválido. Escolha um diretório existente."
 

--- a/addons/yard/editor_only/locale/ru_RU.po
+++ b/addons/yard/editor_only/locale/ru_RU.po
@@ -93,6 +93,10 @@ msgstr ""
 "Директория действительна. Новые ресурсы будут обнаружены автоматически…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "Директория сканирования задана как корень проекта ([code]res://[/code]). При каждом сохранении файла будет сканироваться весь проект, что может привести к значительным задержкам в редакторе."
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "Директория недействительна. Выберите существующую директорию."
 

--- a/addons/yard/editor_only/locale/tr_TR.po
+++ b/addons/yard/editor_only/locale/tr_TR.po
@@ -93,6 +93,10 @@ msgid "Scan directory valid. Will watch for new Resources…"
 msgstr "Dizin geçerli. Yeni kaynaklar otomatik olarak algılanacak…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "Tarama dizini, projenin kök dizinine ([code]res://[/code]) ayarlı. Bu, her dosya kaydında tüm projeyi tarayacak ve editörde önemli performans sorunlarına yol açabilir."
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "Geçersiz dizin. Mevcut bir dizin seçin."
 

--- a/addons/yard/editor_only/locale/zh_CN.po
+++ b/addons/yard/editor_only/locale/zh_CN.po
@@ -92,6 +92,10 @@ msgid "Scan directory valid. Will watch for new Resources…"
 msgstr "目录有效。将自动检测新资源…"
 
 #: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+msgid "Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."
+msgstr "扫描目录已设置为项目根目录（[code]res://[/code]）。每次保存文件时将扫描整个项目，可能导致编辑器明显卡顿。"
+
+#: addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
 msgid "Scan directory invalid. Pick an existing directory."
 msgstr "目录无效。请选择一个已存在的目录。"
 

--- a/addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
+++ b/addons/yard/editor_only/ui_scenes/components/new_registry_dialog.gd
@@ -36,6 +36,7 @@ var INFO_MESSAGES: Dictionary[StringName, Array] = {
 
 	# --- Scan directory ---
 	&"scan_valid": [tr("Scan directory valid. Will watch for new Resources…"), SUCCESS_COLOR],
+	&"scan_root_warning": [tr("Scan directory is set to the project root ([code]res://[/code]). This will scan the entire project on every file save, which may cause significant editor lag."), WARNING_COLOR],
 	&"scan_invalid": [tr("Scan directory invalid. Pick an existing directory."), ERROR_COLOR],
 	&"scan_empty": [tr("No scan directory, resources auto-discovery is disabled."), DEFAULT_COLOR],
 

--- a/addons/yard/editor_only/ui_scenes/components/scan_ruleset_editor/scan_ruleset_editor.gd
+++ b/addons/yard/editor_only/ui_scenes/components/scan_ruleset_editor/scan_ruleset_editor.gd
@@ -300,7 +300,11 @@ func _validate_fields() -> Array[Array]:
 					break
 
 			if all_paths_valid:
-				validation_messages.append([ValidationSubState.SUCCESS, &"scan_valid"])
+				var has_root_dir := all_scan_paths.any(func(p: String) -> bool: return p == "res://")
+				if has_root_dir:
+					validation_messages.append([ValidationSubState.WARNING, &"scan_root_warning"])
+				else:
+					validation_messages.append([ValidationSubState.SUCCESS, &"scan_valid"])
 			else:
 				validation_messages.append([ValidationSubState.ERROR, &"scan_invalid"])
 	else:


### PR DESCRIPTION
## Summary

- Adds a `WARNING` validation state in the registry settings dialog when any scan directory is set to `res://`
- Non-blocking — the OK button stays enabled, as scanning the project root may be intentional on small projects
- Translates the new warning message across all 10 supported locales (fr, de, es, pt_BR, ru, zh_CN, it, pl, tr, en_US)

Closes #78.