### PR TITLE
refactor: centralize logging in a utils class

### DIFF
--- a/addons/yard/editor_only/classes/any_icon.gd
+++ b/addons/yard/editor_only/classes/any_icon.gd
@@ -20,11 +20,11 @@ static var allow_generating_union_icons: bool = true
 ## Shortcut for [method EditorInterface.get_base_control].
 static var base_control: Control = EditorInterface.get_base_control() if Engine.is_editor_hint() else Control.new():
 	set(new):
-		printerr("AnyIcon.base_control is read-only.")
+		push_error("AnyIcon.base_control is read-only.")
 ## The icon displayed when no valid icon is found.
 static var icon_not_found: Texture2D = base_control.get_theme_icon(&""):
 	set(new):
-		printerr("AnyIcon.icon_not_found is read-only.")
+		push_error("AnyIcon.icon_not_found is read-only.")
 
 static var _ICON_ANNOTATION_REGEX := RegEx.create_from_string(
 	r"""@icon\s*?\((?:[^#]*?(?:)*?(?:#.*)*?)*?(?<delimiter>"+|'+)(?<path>.*?)\k<delimiter>(?:.|\n)*?\)""",

--- a/addons/yard/editor_only/classes/editor_theme_utils.gd
+++ b/addons/yard/editor_only/classes/editor_theme_utils.gd
@@ -7,11 +7,11 @@ static var editor_theme: Theme:
 
 static var base_margin: int:
 	get:
-		return editor_theme.get_constant("base_margin", "Editor")
+		return editor_theme.get_constant(&"base_margin", &"Editor")
 
 static var class_icon_size: int:
 	get:
-		return editor_theme.get_constant("class_icon_size", "Editor")
+		return editor_theme.get_constant(&"class_icon_size", &"Editor")
 
 static var scale: float:
 	get:
@@ -19,15 +19,19 @@ static var scale: float:
 
 static var color_error: Color:
 	get:
-		return editor_theme.get_color("error_color", "Editor")
+		return editor_theme.get_color(&"error_color", &"Editor")
 
 static var color_warning: Color:
 	get:
-		return editor_theme.get_color("warning_color", "Editor")
+		return editor_theme.get_color(&"warning_color", &"Editor")
+
+static var color_message: Color:
+	get:
+		return editor_theme.get_color(&"font_color", &"Editor") * Color(1, 1, 1, 0.6)
 
 static var color_success: Color:
 	get:
-		return editor_theme.get_color("success_color", "Editor")
+		return editor_theme.get_color(&"success_color", &"Editor")
 
 
 static func get_base_color(p_dimness_ofs: float = 0.0, p_saturation_mult: float = 1.0) -> Color:

--- a/addons/yard/editor_only/classes/yard_logger.gd
+++ b/addons/yard/editor_only/classes/yard_logger.gd
@@ -1,0 +1,31 @@
+@tool
+extends Object
+
+const EditorThemeUtils := preload("res://addons/yard/editor_only/classes/editor_theme_utils.gd")
+
+
+static func info(message: String) -> void:
+	print_rich(
+		"[color=%s]%s[/color]" % [
+			EditorThemeUtils.color_message.to_html(true),
+			message,
+		],
+	)
+
+
+static func warn(message: String) -> void:
+	print_rich(
+		"[color=%s]● [b]WARNING:[/b] %s[/color]" % [
+			EditorThemeUtils.color_warning.to_html(true),
+			message,
+		],
+	)
+
+
+static func error(message: String) -> void:
+	print_rich(
+		"[color=%s]● [b]ERROR:[/b] %s[/color]" % [
+			EditorThemeUtils.color_error.to_html(true),
+			message,
+		],
+	)

--- a/addons/yard/editor_only/classes/yard_logger.gd.uid
+++ b/addons/yard/editor_only/classes/yard_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://cuuo2gjbmnqni

--- a/addons/yard/editor_only/namespace.gd
+++ b/addons/yard/editor_only/namespace.gd
@@ -7,6 +7,7 @@ const ClassUtils := preload("res://addons/yard/editor_only/classes/class_utils.g
 const EditorThemeUtils := preload("res://addons/yard/editor_only/classes/editor_theme_utils.gd")
 const FuzzySearch := preload("res://addons/yard/editor_only/classes/fuzzy_search.gd")
 const AnyIcon := preload("res://addons/yard/editor_only/classes/any_icon.gd")
+const YardLogger := preload("res://addons/yard/editor_only/classes/yard_logger.gd")
 
 # UI Scenes
 const RegistryEditor := preload("res://addons/yard/editor_only/ui_scenes/registry_editor.gd")

--- a/addons/yard/editor_only/registry_io.gd
+++ b/addons/yard/editor_only/registry_io.gd
@@ -3,9 +3,9 @@ extends Object
 
 const Namespace := preload("res://addons/yard/editor_only/namespace.gd")
 const ClassUtils := Namespace.ClassUtils
+const YardLogger := Namespace.YardLogger
 
 const REGISTRY_FILE_EXTENSIONS := ["tres"]
-const LOGGING_INFO_COLOR := "lightslategray"
 
 
 static func create_registry_file(path: String, settings: RegistrySettings = null) -> Error:
@@ -188,7 +188,7 @@ static func change_entry_uid(registry: Registry, id: StringName, new_uid: String
 	var string_id := registry.get_string_id(old_uid)
 	if registry.has_uid(new_uid):
 		var already_there_string_id := registry.get_string_id(new_uid)
-		push_error(
+		YardLogger.error(
 			"UID Change Error: You can't use %s for '%s', as it's already in the registry as '%s'" % [
 				new_uid,
 				string_id,
@@ -203,7 +203,7 @@ static func change_entry_uid(registry: Registry, id: StringName, new_uid: String
 		var res := load(new_uid)
 		var all_class_restrictions := settings.get_all_class_restrictions()
 		if not does_resource_match_class_restrictions(res, all_class_restrictions):
-			push_error(
+			YardLogger.error(
 				"UID Change Error: The associated resource '%s' doesn't match the registry class restriction (%s)." % [
 					res.resource_path.get_file(),
 					",".join(all_class_restrictions),
@@ -235,9 +235,8 @@ static func sync_from_scan_directories(registry: Registry) -> void:
 
 	var _log := func(action: String, prep: String, n: int, first: String) -> void:
 		if n == 1:
-			print_rich(
-				"[color=%s]%s %s %s %s.[/color]" % [
-					LOGGING_INFO_COLOR,
+			YardLogger.info(
+				"%s %s %s %s." % [
 					action.capitalize(),
 					first,
 					prep,
@@ -245,9 +244,8 @@ static func sync_from_scan_directories(registry: Registry) -> void:
 				],
 			)
 		elif n > 1:
-			print_rich(
-				"[color=%s]%s %s and %d more entr%s %s %s.[/color]" % [
-					LOGGING_INFO_COLOR,
+			YardLogger.info(
+				"%s %s and %d more entr%s %s %s." % [
 					action.capitalize(),
 					first,
 					n - 1,
@@ -283,13 +281,7 @@ static func sync_from_scan_directories(registry: Registry) -> void:
 			if n_removed == 1:
 				first_removed = string_id
 		else:
-			print_rich(
-				"[color=%s]Failed to remove %s from %s.[/color]" % [
-					LOGGING_INFO_COLOR,
-					string_id,
-					registry.resource_path.get_file(),
-				],
-			)
+			YardLogger.warn("Failed to remove %s from %s." % [string_id, registry.resource_path.get_file()])
 
 	_log.call("removed", "from", n_removed, first_removed)
 

--- a/addons/yard/editor_only/ui_scenes/components/dynamic_table.gd
+++ b/addons/yard/editor_only/ui_scenes/components/dynamic_table.gd
@@ -21,6 +21,7 @@ const Namespace := preload("res://addons/yard/editor_only/namespace.gd")
 const ClassUtils := Namespace.ClassUtils
 const EditorThemeUtils := Namespace.EditorThemeUtils
 const AnyIcon := Namespace.AnyIcon
+const YardLogger := preload("res://addons/yard/editor_only/classes/yard_logger.gd")
 
 const H_ALIGNMENT_MARGINS = {
 	HORIZONTAL_ALIGNMENT_LEFT: 5,
@@ -552,7 +553,7 @@ func _start_cell_editing(row: int, col: int) -> void:
 	elif column.is_numeric_column() or column.is_string_column():
 		_open_text_editor(row, col)
 	else:
-		push_warning("There is no editor for this type of cell.")
+		YardLogger.warn("There is no editor for this type of cell.")
 	# NB: boolean cells are toggled using single click
 
 

--- a/addons/yard/editor_only/ui_scenes/components/scan_ruleset_editor/scan_tab_inputs/scan_inputs_tab_container.gd
+++ b/addons/yard/editor_only/ui_scenes/components/scan_ruleset_editor/scan_tab_inputs/scan_inputs_tab_container.gd
@@ -97,7 +97,7 @@ func set_all_values(values: Array[Variant]) -> void:
 func render_validation_results(args: Array[Variant]) -> void:
 	var args_count := args.size()
 	if args_count != _inputs.size():
-		printerr("Validation results args count invalid!")
+		push_error("Validation results args count invalid!")
 		return
 
 	for i in args_count:

--- a/addons/yard/editor_only/ui_scenes/registry_editor.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_editor.gd
@@ -33,6 +33,7 @@ const RegistryTableView := Namespace.RegistryTableView
 const NewRegistryDialog := Namespace.NewRegistryDialog
 const AnyIcon := Namespace.AnyIcon
 const FuzzySearch := Namespace.FuzzySearch
+const YardLogger := Namespace.YardLogger
 const FuzzySearchResult := FuzzySearch.FuzzySearchResult
 const BUILTIN_RESOURCE_PROPERTIES: Array[StringName] = RegistryCacheData.BUILTIN_RESOURCE_PROPERTIES
 
@@ -513,7 +514,7 @@ func _do_file_menu_action(action_id: int) -> void:
 					open_registry(load(uid))
 					return
 				_session_closed_uids.remove_at(idx)
-			push_warning(tr("None of the closed resources exist anymore"))
+			YardLogger.warn(tr("None of the closed resources exist anymore"))
 		FileMenuAction.CLOSE:
 			if is_any_registry_selected(): # check because of shortcut
 				close_registry(_current_registry_uid)
@@ -567,8 +568,9 @@ func _sort_opened_registries_by_filename() -> void:
 	var sorted: Dictionary[String, Registry] = { }
 	keys.sort_custom(
 		func(a: String, b: String) -> bool:
-			return _editor_state_data.opened_registries[a].resource_path.get_file().to_lower() \
-			< _editor_state_data.opened_registries[b].resource_path.get_file().to_lower()
+			var filename_a := _editor_state_data.opened_registries[a].resource_path.get_file().to_lower()
+			var filename_b := _editor_state_data.opened_registries[b].resource_path.get_file().to_lower()
+			return filename_a < filename_b
 	)
 	for uid in keys:
 		sorted[uid] = _editor_state_data.opened_registries[uid]
@@ -681,9 +683,9 @@ func _on_file_dialog_action(path: String) -> void:
 	if res is Registry:
 		open_registry(res)
 	elif res.get_script():
-		push_error("Tried to open %s as a Registry" % res.get_script().get_global_name())
+		YardLogger.error("Tried to open %s as a Registry" % res.get_script().get_global_name())
 	else:
-		push_error("Tried to open %s as a Registry" % res.get_class())
+		YardLogger.error("Tried to open %s as a Registry" % res.get_class())
 
 
 func _on_refresh_view_button_pressed() -> void:

--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -21,6 +21,7 @@ const RegistryIO := Namespace.RegistryIO
 const ClassUtils := Namespace.ClassUtils
 const EditorThemeUtils := Namespace.EditorThemeUtils
 const DynamicTable := Namespace.DynamicTable
+const YardLogger := Namespace.YardLogger
 const RegistryCacheData := Namespace.YardEditorCache.RegistryCacheData
 
 const ACCELERATORS_WIN: Dictionary = {
@@ -42,7 +43,6 @@ const ACCELERATORS_MAC: Dictionary = {
 }
 
 const INVALID_UID := "uid://<invalid>"
-const LOGGING_INFO_COLOR := "lightslategray"
 const UID_COLUMN_CONFIG := ["uid", "UID", TYPE_STRING]
 const STRINGID_COLUMN_CONFIG := ["string_id", "String ID", TYPE_STRING]
 const NON_PROP_COLUMNS_COUNT := 2
@@ -156,9 +156,7 @@ func _process(_delta: float) -> void:
 		_texture_rect_parent.custom_minimum_size = Vector2(1, 1)
 
 	if not get_viewport().gui_is_dragging():
-		drag_and_drop_info_panel.visible = (
-			current_registry and current_registry.is_empty()
-		)
+		drag_and_drop_info_panel.visible = current_registry and current_registry.is_empty()
 
 
 func _notification(what: int) -> void:
@@ -224,7 +222,7 @@ func _drop_data(_at_position: Vector2, data: Variant) -> void:
 					)
 					n_added += int(status == OK)
 
-	print_rich("[color=%s]Added %s new Resources to the registry.[/color]" % [LOGGING_INFO_COLOR, n_added])
+	YardLogger.info("Added %s new Resources to the registry." % n_added)
 	update_view()
 
 
@@ -487,12 +485,7 @@ func _edit_entry_property(entry: StringName, property: StringName, old_value: Va
 
 	var res := load(entry)
 	if not property in res:
-		print_rich(
-			"[color=%s]● [b]ERROR:[/b] Property %s not in resource[/color]" % [
-				EditorThemeUtils.color_error.to_html(false),
-				property,
-			],
-		)
+		YardLogger.error("Property %s not in resource" % property)
 		return
 
 	var prop_types := ClassUtils.get_property_declared_types(res, property)
@@ -518,9 +511,8 @@ func _edit_entry_property(entry: StringName, property: StringName, old_value: Va
 			break
 
 	if not valid:
-		print_rich(
-			"[color=%s]● [b]ERROR:[/b] Invalid type. Couldn't set %s (%s) to %s (%s)[/color]" % [
-				EditorThemeUtils.color_error.to_html(false),
+		YardLogger.error(
+			"Invalid type. Couldn't set %s (%s) to %s (%s)" % [
 				property,
 				", ".join(prop_types),
 				new_value,
@@ -532,9 +524,8 @@ func _edit_entry_property(entry: StringName, property: StringName, old_value: Va
 	res.set(property, new_value)
 	var old_is_string := typeof(old_value) in [TYPE_STRING, TYPE_STRING_NAME]
 	var new_is_string := typeof(res.get(property)) in [TYPE_STRING, TYPE_STRING_NAME]
-	print_rich(
-		"[color=%s]Set %s—>%s from %s to %s[/color]" % [
-			LOGGING_INFO_COLOR,
+	YardLogger.info(
+		"Set %s—>%s from %s to %s" % [
 			current_registry.get_string_id(uid),
 			property,
 			'"' + old_value + '"' if old_is_string else old_value,
@@ -586,11 +577,11 @@ func _add_entry_from_picker(res: Resource, string_id: StringName) -> void:
 		var current_dir := EditorInterface.get_current_path().get_base_dir()
 		var save_path := current_dir.path_join(str(string_id) + ".tres")
 		if ResourceLoader.exists(save_path):
-			_print_fake_error("A file already exists at '%s'. Choose a different String ID or save the resource manually first." % save_path)
+			YardLogger.error("A file already exists at '%s'. Choose a different String ID or save the resource manually first." % save_path)
 			return
 		var save_status := ResourceSaver.save(res, save_path, ResourceSaver.FLAG_CHANGE_PATH)
 		if save_status != OK:
-			_print_fake_error("Failed to save resource to '%s'." % save_path)
+			YardLogger.error("Failed to save resource to '%s'." % save_path)
 			return
 		EditorInterface.get_editor_toaster().push_toast("Resource saved to %s" % save_path)
 		res = load(save_path) # Required because of race condition shinenigans I guess
@@ -606,15 +597,15 @@ func _add_entry_from_picker(res: Resource, string_id: StringName) -> void:
 			_toggle_add_entry_button()
 			update_view()
 		ERR_ALREADY_EXISTS:
-			_print_fake_error("An entry with the same UID already exists in the registry.")
+			YardLogger.error("An entry with the same UID already exists in the registry.")
 		ERR_CANT_ACQUIRE_RESOURCE:
-			_print_fake_error("This resource is not saved as a file. Click [b]⌄[/b] then [b]Save[/b] on the resource picker to save it first.")
+			YardLogger.error("This resource is not saved as a file. Click [b]⌄[/b] then [b]Save[/b] on the resource picker to save it first.")
 		ERR_INVALID_PARAMETER:
-			_print_fake_error("The String ID is invalid. It must not start with 'uid://'.")
+			YardLogger.error("The String ID is invalid. It must not start with 'uid://'.")
 		ERR_DATABASE_CANT_WRITE:
-			_print_fake_error("This resource doesn't match the registry class restriction.")
+			YardLogger.error("This resource doesn't match the registry class restriction.")
 		_:
-			_print_fake_error("Failed to add entry to the registry.")
+			YardLogger.error("Failed to add entry to the registry.")
 
 
 func _toggle_add_entry_button() -> void:
@@ -631,7 +622,7 @@ func _delete_selected_entries() -> void:
 	for row_idx: int in dynamic_table.selected_rows:
 		var uid := get_row_resource_uid(row_idx)
 		if RegistryIO.erase_entry(current_registry, uid) != OK:
-			_print_fake_error(
+			YardLogger.error(
 				"Failed to remove %s from %s." % [uid, current_registry.resource_path.get_file()],
 			)
 
@@ -643,7 +634,7 @@ func _duplicate_selected_entries() -> void:
 	for row_idx: int in dynamic_table.selected_rows:
 		var uid := get_row_resource_uid(row_idx)
 		if RegistryIO.duplicate_entry(current_registry, uid) != OK:
-			_print_fake_error(
+			YardLogger.error(
 				"Failed to duplicate %s in %s." % [uid, current_registry.resource_path.get_file()],
 			)
 	update_view()
@@ -667,15 +658,6 @@ func _invert_selection() -> void:
 func _unselect() -> void:
 	dynamic_table.selected_rows = []
 	dynamic_table.queue_redraw()
-
-
-func _print_fake_error(message: String) -> void:
-	print_rich(
-		"[color=%s]● [b]ERROR:[/b] %s[/color]" % [
-			EditorThemeUtils.color_error.to_html(false),
-			message,
-		],
-	)
 
 
 func _on_drag_begin() -> void:


### PR DESCRIPTION
## Description

<!-- What does this PR change and why? Link any related issue. -->

The logging was too fragmented, with some logging functions for faking error messages being duplicated.

Now centralized in a `yard_logger.gd` class with static methods.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
