### PR TITLE
feat: add visibility toggles for UID/String UID columns

### DIFF
--- a/addons/yard/editor_only/locale/de_DE.po
+++ b/addons/yard/editor_only/locale/de_DE.po
@@ -327,14 +327,6 @@ msgstr "UID anzeigen"
 msgid "Shows the UID of the resource in the second column."
 msgstr "Zeigt die UID der Ressource in der zweiten Spalte an."
 
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "String ID anzeigen"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "Zeigt die String ID der Ressource in der ersten Spalte an."
-
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Neue Registrierung…"

--- a/addons/yard/editor_only/locale/de_DE.po
+++ b/addons/yard/editor_only/locale/de_DE.po
@@ -319,6 +319,22 @@ msgstr ""
 "Spalten neu anordnen, sodass Eigenschaften der Elternklasse vor denen der Unterklassen erscheinen.\n"
 "Standardmäßig folgen die Spalten der Inspektor-Reihenfolge (Unterklassen-Eigenschaften zuerst)."
 
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "UID anzeigen"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "Zeigt die UID der Ressource in der zweiten Spalte an."
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "String ID anzeigen"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "Zeigt die String ID der Ressource in der ersten Spalte an."
+
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Neue Registrierung…"

--- a/addons/yard/editor_only/locale/en_US.po
+++ b/addons/yard/editor_only/locale/en_US.po
@@ -310,6 +310,23 @@ msgstr ""
 "Reorder columns so parent class properties appear before subclass ones.\n"
 "By default, columns follow the inspector order (subclass properties first)."
 
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "Show UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "Shows the UID of the resource in the second column."
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "Show String ID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "Shows the String ID of the resource in the first column."
+
+
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "New Registry..."

--- a/addons/yard/editor_only/locale/en_US.po
+++ b/addons/yard/editor_only/locale/en_US.po
@@ -318,15 +318,6 @@ msgstr "Show UID"
 msgid "Shows the UID of the resource in the second column."
 msgstr "Shows the UID of the resource in the second column."
 
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "Show String ID"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "Shows the String ID of the resource in the first column."
-
-
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "New Registry..."

--- a/addons/yard/editor_only/locale/es_ES.po
+++ b/addons/yard/editor_only/locale/es_ES.po
@@ -327,14 +327,6 @@ msgstr "Mostrar UID"
 msgid "Shows the UID of the resource in the second column."
 msgstr "Muestra el UID del recurso en la segunda columna."
 
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "Mostrar String ID"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "Muestra la String ID del recurso en la primera columna."
-
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Nuevo registro…"

--- a/addons/yard/editor_only/locale/es_ES.po
+++ b/addons/yard/editor_only/locale/es_ES.po
@@ -319,6 +319,22 @@ msgstr ""
 "Reordena las columnas para que las propiedades de la clase padre aparezcan antes que las de las subclases.\n"
 "Por defecto, las columnas siguen el orden del inspector (propiedades de la subclase primero)."
 
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "Mostrar UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "Muestra el UID del recurso en la segunda columna."
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "Mostrar String ID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "Muestra la String ID del recurso en la primera columna."
+
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Nuevo registro…"

--- a/addons/yard/editor_only/locale/fr_FR.po
+++ b/addons/yard/editor_only/locale/fr_FR.po
@@ -327,14 +327,6 @@ msgstr "Afficher l'UID"
 msgid "Shows the UID of the resource in the second column."
 msgstr "Affiche l'UID de la ressource dans la deuxième colonne."
 
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "Afficher String ID"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "Affiche la String ID de la ressource dans la première colonne."
-
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Nouveau registre…"

--- a/addons/yard/editor_only/locale/fr_FR.po
+++ b/addons/yard/editor_only/locale/fr_FR.po
@@ -319,6 +319,22 @@ msgstr ""
 "Réordonne les colonnes pour afficher les propriétés des classes parentes avant celles des sous-classes.\n"
 "Par défaut, les colonnes suivent l'ordre de l'inspecteur (propriétés de la sous-classe en premier)."
 
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "Afficher l'UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "Affiche l'UID de la ressource dans la deuxième colonne."
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "Afficher String ID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "Affiche la String ID de la ressource dans la première colonne."
+
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Nouveau registre…"

--- a/addons/yard/editor_only/locale/it_IT.po
+++ b/addons/yard/editor_only/locale/it_IT.po
@@ -324,14 +324,6 @@ msgstr "Mostra UID"
 msgid "Shows the UID of the resource in the second column."
 msgstr "Mostra l'UID della risorsa nella seconda colonna."
 
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "Mostra String ID"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "Mostra la String ID della risorsa nella prima colonna."
-
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Nuovo registro…"

--- a/addons/yard/editor_only/locale/it_IT.po
+++ b/addons/yard/editor_only/locale/it_IT.po
@@ -316,6 +316,22 @@ msgstr ""
 "Riordina le colonne in modo che le proprietà della classe padre appaiano prima di quelle delle sottoclassi.\n"
 "Per impostazione predefinita, le colonne seguono l'ordine dell'inspector (proprietà della sottoclasse per prime)."
 
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "Mostra UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "Mostra l'UID della risorsa nella seconda colonna."
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "Mostra String ID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "Mostra la String ID della risorsa nella prima colonna."
+
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Nuovo registro…"

--- a/addons/yard/editor_only/locale/pl_PL.po
+++ b/addons/yard/editor_only/locale/pl_PL.po
@@ -320,14 +320,6 @@ msgstr "Pokaż UID"
 msgid "Shows the UID of the resource in the second column."
 msgstr "Wyświetla UID zasobu w drugiej kolumnie."
 
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "Pokaż String ID"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "Wyświetla String ID zasobu w pierwszej kolumnie."
-
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Nowy rejestr…"

--- a/addons/yard/editor_only/locale/pl_PL.po
+++ b/addons/yard/editor_only/locale/pl_PL.po
@@ -312,6 +312,22 @@ msgstr ""
 "Zmienia kolejność kolumn tak, aby właściwości klasy nadrzędnej pojawiały się przed właściwościami podklas.\n"
 "Domyślnie kolumny odpowiadają kolejności inspektora (właściwości podklasy jako pierwsze)."
 
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "Pokaż UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "Wyświetla UID zasobu w drugiej kolumnie."
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "Pokaż String ID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "Wyświetla String ID zasobu w pierwszej kolumnie."
+
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Nowy rejestr…"

--- a/addons/yard/editor_only/locale/pt_BR.po
+++ b/addons/yard/editor_only/locale/pt_BR.po
@@ -318,6 +318,22 @@ msgstr ""
 "Reordena as colunas para que as propriedades da classe pai apareçam antes das subclasses.\n"
 "Por padrão, as colunas seguem a ordem do inspetor (propriedades da subclasse primeiro)."
 
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "Mostrar UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "Mostra o UID do recurso na segunda coluna."
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "Mostrar a String ID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "Mostra a String ID do recurso na primeira coluna."
+
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Novo registro…"

--- a/addons/yard/editor_only/locale/pt_BR.po
+++ b/addons/yard/editor_only/locale/pt_BR.po
@@ -326,14 +326,6 @@ msgstr "Mostrar UID"
 msgid "Shows the UID of the resource in the second column."
 msgstr "Mostra o UID do recurso na segunda coluna."
 
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "Mostrar a String ID"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "Mostra a String ID do recurso na primeira coluna."
-
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Novo registro…"

--- a/addons/yard/editor_only/locale/ru_RU.po
+++ b/addons/yard/editor_only/locale/ru_RU.po
@@ -313,6 +313,22 @@ msgstr ""
 "Переупорядочивает столбцы так, чтобы свойства родительского класса отображались перед свойствами подклассов.\n"
 "По умолчанию столбцы следуют порядку инспектора (свойства подкласса первыми)."
 
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "Показать UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "Показывает UID ресурса во втором столбце."
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "Показать String ID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "Показывает String ID ресурса в первом столбце."
+
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Новый реестр…"

--- a/addons/yard/editor_only/locale/ru_RU.po
+++ b/addons/yard/editor_only/locale/ru_RU.po
@@ -321,14 +321,6 @@ msgstr "Показать UID"
 msgid "Shows the UID of the resource in the second column."
 msgstr "Показывает UID ресурса во втором столбце."
 
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "Показать String ID"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "Показывает String ID ресурса в первом столбце."
-
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Новый реестр…"

--- a/addons/yard/editor_only/locale/tr_TR.po
+++ b/addons/yard/editor_only/locale/tr_TR.po
@@ -314,6 +314,22 @@ msgstr ""
 "Sütunları, üst sınıf özelliklerinin alt sınıf özelliklerinden önce görünmesi için yeniden sıralar.\n"
 "Varsayılan olarak sütunlar inspector sırasını takip eder (alt sınıf özellikleri önce)."
 
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "UID Göster"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "Kaynağın UID'sini ikinci sütunda gösterir."
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "String ID Göster"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "Kaynağın String ID'sini ilk sütunda gösterir."
+
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Yeni kayıt defteri…"

--- a/addons/yard/editor_only/locale/tr_TR.po
+++ b/addons/yard/editor_only/locale/tr_TR.po
@@ -322,14 +322,6 @@ msgstr "UID Göster"
 msgid "Shows the UID of the resource in the second column."
 msgstr "Kaynağın UID'sini ikinci sütunda gösterir."
 
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "String ID Göster"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "Kaynağın String ID'sini ilk sütunda gösterir."
-
 #: addons/yard/editor_only/ui_scenes/registry_editor.tscn
 msgid "New Registry..."
 msgstr "Yeni kayıt defteri…"

--- a/addons/yard/editor_only/locale/zh_CN.po
+++ b/addons/yard/editor_only/locale/zh_CN.po
@@ -294,6 +294,22 @@ msgid "Show Parent Properties First"
 msgstr "优先显示父类属性"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show UID"
+msgstr "显示 UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the UID of the resource in the second column."
+msgstr "在第二列显示资源的 UID。"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Show String ID"
+msgstr "显示 String ID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Shows the String ID of the resource in the first column."
+msgstr "在第一列显示资源的 String ID。"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid ""
 "Reorder columns so parent class properties appear before subclass ones.\n"
 "By default, columns follow the inspector order (subclass properties first)."

--- a/addons/yard/editor_only/locale/zh_CN.po
+++ b/addons/yard/editor_only/locale/zh_CN.po
@@ -302,14 +302,6 @@ msgid "Shows the UID of the resource in the second column."
 msgstr "在第二列显示资源的 UID。"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Show String ID"
-msgstr "显示 String ID"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Shows the String ID of the resource in the first column."
-msgstr "在第一列显示资源的 String ID。"
-
-#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid ""
 "Reorder columns so parent class properties appear before subclass ones.\n"
 "By default, columns follow the inspector order (subclass properties first)."

--- a/addons/yard/editor_only/ui_scenes/registry_editor.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_editor.gd
@@ -458,6 +458,19 @@ func _populate_columns_popup_menu() -> void:
 		registry_table_view.current_cache_data.parent_props_first,
 	)
 
+	_add_check_item(
+		popup,
+		tr("Show UID"),
+		tr("Shows the UID of the resource in the second column."),
+		registry_table_view.show_uid,
+	)
+	_add_check_item(
+		popup,
+		tr("Show String ID"),
+		tr("Shows the String ID of the resource in the first column."),
+		registry_table_view.show_string_id,
+	)
+
 	if not registry_table_view.properties_column_info:
 		return
 
@@ -660,6 +673,14 @@ func _on_columns_menu_id_pressed(id: int) -> void:
 			popup.toggle_item_checked(1)
 			registry_table_view.current_cache_data.parent_props_first = popup.is_item_checked(1)
 			registry_table_view.current_cache_data.save()
+			registry_table_view.update_view()
+		2: # Show UID
+			popup.toggle_item_checked(2)
+			registry_table_view.show_uid = popup.is_item_checked(2)
+			registry_table_view.update_view()
+		3: # Show String ID
+			popup.toggle_item_checked(3)
+			registry_table_view.show_string_id = popup.is_item_checked(3)
 			registry_table_view.update_view()
 		_:
 			var prop_name: StringName = popup.get_item_tooltip(id)

--- a/addons/yard/editor_only/ui_scenes/registry_editor.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_editor.gd
@@ -464,12 +464,6 @@ func _populate_columns_popup_menu() -> void:
 		tr("Shows the UID of the resource in the second column."),
 		registry_table_view.show_uid,
 	)
-	_add_check_item(
-		popup,
-		tr("Show String ID"),
-		tr("Shows the String ID of the resource in the first column."),
-		registry_table_view.show_string_id,
-	)
 
 	if not registry_table_view.properties_column_info:
 		return
@@ -677,10 +671,6 @@ func _on_columns_menu_id_pressed(id: int) -> void:
 		2: # Show UID
 			popup.toggle_item_checked(2)
 			registry_table_view.show_uid = popup.is_item_checked(2)
-			registry_table_view.update_view()
-		3: # Show String ID
-			popup.toggle_item_checked(3)
-			registry_table_view.show_string_id = popup.is_item_checked(3)
 			registry_table_view.update_view()
 		_:
 			var prop_name: StringName = popup.get_item_tooltip(id)

--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -82,11 +82,6 @@ var show_uid := true:
 		update_view()
 		_build_columns()
 
-var show_string_id := true:
-	set(show):
-		show_string_id = show
-		update_view()
-		_build_columns()
 
 var _texture_rect_parent: Button
 var _res_picker: EditorResourcePicker
@@ -256,9 +251,7 @@ func update_view() -> void:
 	set_columns_data(resources.values())
 	entries_data.clear()
 	for uid in current_registry.get_all_uids():
-		var entry_data := []
-		if show_string_id:
-			entry_data.append(current_registry.get_string_id(uid))
+		var entry_data := [current_registry.get_string_id(uid)]
 		if show_uid:
 			entry_data.append(uid)
 		if RegistryIO.is_uid_valid(uid):
@@ -419,11 +412,10 @@ func toggle_edit_menu_items(edit_menu: PopupMenu) -> void:
 func _build_columns() -> Array[DynamicTable.ColumnConfig]:
 	var columns: Array[DynamicTable.ColumnConfig] = []
 
-	if show_string_id:
-		var string_id_column: DynamicTable.ColumnConfig = DynamicTable.ColumnConfig.new.callv(STRINGID_COLUMN_CONFIG)
-		string_id_column.custom_font_color = get_theme_color(&"accent_color", &"Editor")
-		string_id_column.h_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-		columns.append(string_id_column) #0
+	var string_id_column: DynamicTable.ColumnConfig = DynamicTable.ColumnConfig.new.callv(STRINGID_COLUMN_CONFIG)
+	string_id_column.custom_font_color = get_theme_color(&"accent_color", &"Editor")
+	string_id_column.h_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	columns.append(string_id_column) #0
 
 	if show_uid:
 		var uid_column: DynamicTable.ColumnConfig = DynamicTable.ColumnConfig.new.callv(UID_COLUMN_CONFIG)

--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -76,6 +76,18 @@ var id_columns_frozen := true:
 		dynamic_table.n_frozen_columns = 2 if frozen else 0
 		dynamic_table._update_scrollbars() # private but whatever
 
+var show_uid := true:
+	set(show):
+		show_uid = show
+		update_view()
+		_build_columns()
+
+var show_string_id := true:
+	set(show):
+		show_string_id = show
+		update_view()
+		_build_columns()
+
 var _texture_rect_parent: Button
 var _res_picker: EditorResourcePicker
 var _uid_resource_to_inspect: String
@@ -244,7 +256,11 @@ func update_view() -> void:
 	set_columns_data(resources.values())
 	entries_data.clear()
 	for uid in current_registry.get_all_uids():
-		var entry_data := [current_registry.get_string_id(uid), uid]
+		var entry_data := []
+		if show_string_id:
+			entry_data.append(current_registry.get_string_id(uid))
+		if show_uid:
+			entry_data.append(uid)
 		if RegistryIO.is_uid_valid(uid):
 			entry_data.append_array(get_res_row_data(current_registry.load_entry(uid)))
 		else:
@@ -403,15 +419,18 @@ func toggle_edit_menu_items(edit_menu: PopupMenu) -> void:
 func _build_columns() -> Array[DynamicTable.ColumnConfig]:
 	var columns: Array[DynamicTable.ColumnConfig] = []
 
-	var string_id_column: DynamicTable.ColumnConfig = DynamicTable.ColumnConfig.new.callv(STRINGID_COLUMN_CONFIG)
-	string_id_column.custom_font_color = get_theme_color(&"accent_color", &"Editor")
-	string_id_column.h_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-	columns.append(string_id_column) #0
+	if show_string_id:
+		var string_id_column: DynamicTable.ColumnConfig = DynamicTable.ColumnConfig.new.callv(STRINGID_COLUMN_CONFIG)
+		string_id_column.custom_font_color = get_theme_color(&"accent_color", &"Editor")
+		string_id_column.h_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+		columns.append(string_id_column) #0
 
-	var uid_column: DynamicTable.ColumnConfig = DynamicTable.ColumnConfig.new.callv(UID_COLUMN_CONFIG)
-	uid_column.custom_font_color = get_theme_color(&"disabled_font_color", &"Editor")
-	uid_column.property_hint = PROPERTY_HINT_FILE
-	columns.append(uid_column) #1
+	if show_uid:
+		var uid_column: DynamicTable.ColumnConfig = DynamicTable.ColumnConfig.new.callv(UID_COLUMN_CONFIG)
+		uid_column.custom_font_color = get_theme_color(&"disabled_font_color", &"Editor")
+		uid_column.property_hint = PROPERTY_HINT_FILE
+		columns.append(uid_column) #1
+
 
 	for prop in properties_column_info:
 		if not _can_display_property(prop) or is_property_disabled(prop):


### PR DESCRIPTION
* feat: add visibility toggles for UID/String UID columns

## Description

This feat adds 2 new options under the "Columns" popup witch toggles the visibility of the columns: "String ID" and "UID". I Also added translation to the toggles.

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
