### PR TITLE
refactor: use identifiers instead of indices for columns and rows in DynamicTable

### DIFF
--- a/addons/yard/editor_only/classes/yard_logger.gd
+++ b/addons/yard/editor_only/classes/yard_logger.gd
@@ -1,7 +1,8 @@
 @tool
 extends Object
 
-const EditorThemeUtils := preload("res://addons/yard/editor_only/classes/editor_theme_utils.gd")
+const Namespace := preload("res://addons/yard/editor_only/namespace.gd")
+const EditorThemeUtils := Namespace.EditorThemeUtils
 
 
 static func info(message: String) -> void:

--- a/addons/yard/editor_only/ui_scenes/components/dynamic_table.gd
+++ b/addons/yard/editor_only/ui_scenes/components/dynamic_table.gd
@@ -79,7 +79,6 @@ var sort_ascending: bool = true
 var _rows: Dictionary[StringName, Array] = { }
 var _base_order: Array[StringName] = [] # insertion order, source for filter
 var _order: Array[StringName] = [] # current visible filtered / sorted order
-var _total_rows := 0
 var _anchor_row: StringName = &"" # shift-select range anchor
 
 # Column model: the ordered list is both the model and the display order
@@ -220,7 +219,7 @@ func _draw() -> void:
 	_draw_header_column_range(n_frozen_columns, _columns.size(), scroll_x, frozen_w, vis_w)
 
 	for row_idx in range(_visible_rows_range[0], _visible_rows_range[1]):
-		if row_idx >= _total_rows:
+		if row_idx >= _order.size():
 			continue
 		var row := _order[row_idx]
 		var row_y := y_offset + (row_idx - _visible_rows_range[0]) * row_height
@@ -234,7 +233,7 @@ func _draw() -> void:
 	# Pass 2: frozen columns drawn on top
 	if n_frozen_columns > 0:
 		for row_idx in range(_visible_rows_range[0], _visible_rows_range[1]):
-			if row_idx >= _total_rows:
+			if row_idx >= _order.size():
 				continue
 			var row := _order[row_idx]
 			var row_y := y_offset + (row_idx - _visible_rows_range[0]) * row_height
@@ -248,7 +247,7 @@ func _draw() -> void:
 		draw_rect(Rect2(0, 0, frozen_w, header_height), header_color)
 		_draw_header_column_range(0, n_frozen_columns, 0.0, 0.0, vis_w)
 
-		var separator_bottom := header_height + mini(_total_rows, _visible_rows_range[1] - _visible_rows_range[0]) * row_height
+		var separator_bottom := header_height + mini(_order.size(), _visible_rows_range[1] - _visible_rows_range[0]) * row_height
 		draw_line(Vector2(frozen_w, 0), Vector2(frozen_w, separator_bottom), grid_color.darkened(0.2), 2.0)
 
 		if _v_scroll.visible:
@@ -301,7 +300,7 @@ func set_columns(columns: Array[ColumnConfig]) -> void:
 
 
 func get_column(col: StringName) -> ColumnConfig:
-	var idx := _column_index_by_id.get(col, -1)
+	var idx: int = _column_index_by_id.get(col, -1)
 	return _columns[idx] if idx >= 0 else null
 
 
@@ -325,8 +324,7 @@ func set_data(rows: Array, row_ids: Array[StringName]) -> void:
 		_base_order.append(row)
 	_order = _base_order.duplicate()
 
-	_total_rows = _order.size()
-	_visible_rows_range = [0, min(_total_rows, floori(size.y / row_height) if row_height > 0 else 0)]
+	_visible_rows_range = [0, min(_order.size(), floori(size.y / row_height) if row_height > 0 else 0)]
 
 	# Pad short rows
 	for row in _order:
@@ -373,7 +371,6 @@ func add_row(row: StringName, cells: Array) -> void:
 		_rows[row].append(CELL_INVALID)
 	_base_order.append(row)
 	_order.append(row)
-	_total_rows = _order.size()
 	_update_scrollbars()
 	queue_redraw()
 
@@ -391,7 +388,6 @@ func remove_row(row: StringName) -> void:
 		focused_col = &""
 	if _anchor_row == row:
 		_anchor_row = &""
-	_total_rows = _order.size()
 	_update_scrollbars()
 	queue_redraw()
 
@@ -572,9 +568,8 @@ func _reset_column_widths() -> void:
 func _update_scrollbars() -> void:
 	if not is_inside_tree():
 		return
-	if _total_rows == null or row_height == null:
-		_total_rows = 0 if _total_rows == null else _total_rows
-		row_height = 30.0 if row_height == null or row_height <= 0 else row_height
+	if row_height <= 0:
+		row_height = 30.0
 
 	var visible_width := size.x - (_v_scroll.size.x if _v_scroll.visible else 0.)
 	var visible_height := size.y - (_h_scroll.size.y if _h_scroll.visible else 0.) - header_height
@@ -593,7 +588,7 @@ func _update_scrollbars() -> void:
 	else:
 		_h_scroll.value = 0
 
-	var total_content_height := float(_total_rows) * row_height
+	var total_content_height := float(_order.size()) * row_height
 	_v_scroll.visible = total_content_height > visible_height
 	if _v_scroll.visible:
 		_v_scroll.max_value = total_content_height + row_height / 2
@@ -1246,7 +1241,6 @@ func _apply_filter(search_key: String) -> void:
 				if cell_value.contains(key_lower):
 					_order.append(row)
 
-	_total_rows = _order.size()
 	_v_scroll.value = 0
 
 	# Keep selection only for rows still visible after filter
@@ -1308,7 +1302,7 @@ func _get_row_at_y(y: float) -> int:
 	if y < header_height or row_height <= 0:
 		return -1
 	var row: int = floori((y - header_height) / row_height) + _visible_rows_range[0]
-	return row if row < _total_rows else -1
+	return row if row < _order.size() else -1
 
 
 func _get_text_baseline_y(cell_y: float, cell_height: float = -1.0) -> float:
@@ -1406,7 +1400,7 @@ func _toggle_checkbox(row: StringName, col: StringName) -> void:
 
 func _ensure_row_visible(row: StringName) -> void:
 	var row_idx := _order.find(row)
-	if row_idx < 0 or _total_rows == 0 or row_height == 0 or not _v_scroll.visible:
+	if row_idx < 0 or _order.is_empty() or row_height == 0 or not _v_scroll.visible:
 		return
 
 	var visible_area_height: float = size.y - header_height - (_h_scroll.size.y if _h_scroll.visible else 0.0)
@@ -1711,7 +1705,7 @@ func _handle_key_input(event: InputEventKey) -> void:
 			_finalize_key_operation()
 			return
 		KEY_A:
-			if is_ctrl_cmd and _total_rows > 0:
+			if is_ctrl_cmd and not _order.is_empty():
 				select_all_rows()
 				multiple_rows_selected.emit(selected_rows)
 				_finalize_key_operation()
@@ -1723,14 +1717,14 @@ func _handle_key_input(event: InputEventKey) -> void:
 			_finalize_key_operation()
 			return
 		KEY_HOME:
-			if _total_rows == 0:
+			if _order.is_empty():
 				return
 			new_idx = 0
 			new_col_idx = 0 if not _columns.is_empty() else -1
 		KEY_END:
-			if _total_rows == 0:
+			if _order.is_empty():
 				return
-			new_idx = _total_rows - 1
+			new_idx = _order.size() - 1
 			new_col_idx = _columns.size() - 1 if not _columns.is_empty() else -1
 		KEY_UP:
 			if not is_cell_focused:
@@ -1739,7 +1733,7 @@ func _handle_key_input(event: InputEventKey) -> void:
 		KEY_DOWN:
 			if not is_cell_focused:
 				return
-			new_idx = mini(_total_rows - 1, focused_idx + 1)
+			new_idx = mini(_order.size() - 1, focused_idx + 1)
 		KEY_LEFT:
 			if not is_cell_focused:
 				return
@@ -1755,7 +1749,7 @@ func _handle_key_input(event: InputEventKey) -> void:
 		KEY_PAGEDOWN:
 			if not is_cell_focused:
 				return
-			new_idx = mini(_total_rows - 1, focused_idx + _page_row_count())
+			new_idx = mini(_order.size() - 1, focused_idx + _page_row_count())
 		KEY_SPACE:
 			if not is_cell_focused or not is_ctrl_cmd:
 				return
@@ -1793,7 +1787,7 @@ func _page_row_count() -> int:
 	return maxi(1, floori((size.y - header_height) / row_height) if row_height > 0 else 10)
 
 
-func _update_selection_after_navigation(old_row: StringName, old_idx: int, is_shift: bool, is_ctrl_cmd: bool) -> void:
+func _update_selection_after_navigation(old_row: StringName, _old_idx: int, is_shift: bool, is_ctrl_cmd: bool) -> void:
 	if is_shift:
 		if _anchor_row == &"":
 			_anchor_row = old_row if old_row != &"" else (_order[0] if not _order.is_empty() else &"")
@@ -1803,7 +1797,7 @@ func _update_selection_after_navigation(old_row: StringName, old_idx: int, is_sh
 		var focus_idx := _order.find(focused_row)
 		selected_rows.clear()
 		for i in range(mini(anchor_idx, focus_idx), maxi(anchor_idx, focus_idx) + 1):
-			if i >= 0 and i < _total_rows:
+			if i >= 0 and i < _order.size():
 				selected_rows.append(_order[i])
 		if selected_rows.size() > 1:
 			multiple_rows_selected.emit(selected_rows)
@@ -1895,9 +1889,9 @@ func _on_v_scroll_value_changed(value: float) -> void:
 	if row_height > 0:
 		_visible_rows_range[0] = floori(value / row_height)
 		_visible_rows_range[1] = _visible_rows_range[0] + floori((size.y - header_height) / row_height) + 1
-		_visible_rows_range[1] = min(_visible_rows_range[1], _total_rows)
+		_visible_rows_range[1] = min(_visible_rows_range[1], _order.size())
 	else:
-		_visible_rows_range = [0, _total_rows]
+		_visible_rows_range = [0, _order.size()]
 
 	if _text_editor_line_edit.visible:
 		_finish_editing(false)

--- a/addons/yard/editor_only/ui_scenes/components/dynamic_table.gd
+++ b/addons/yard/editor_only/ui_scenes/components/dynamic_table.gd
@@ -1,27 +1,25 @@
-# MIT License
-# Copyright (c) 2025 Giuseppe Pica (jospic)
+# Originally based on dynamicdatatable by Giuseppe Pica (jospic), MIT licensed.
 # https://github.com/jospic/dynamicdatatable
+# Heavily modified / rewritten by Elliot Fontaine, 2026
 
 # BEHOLD THE 2000-LINES BEAST.
-# Original was probably vibe-coded, but it does the job nonetheless
 
 @tool
 extends Control
 
-# Signals
-signal cell_selected(row: int, col: int)
-signal multiple_rows_selected(selected_row_indices: Array)
-signal cell_right_selected(row: int, col: int, mousepos: Vector2)
+signal cell_selected(row_id: StringName, col: int)
+signal multiple_rows_selected(row_ids: Array[StringName])
+signal cell_right_selected(row_id: StringName, col: int, mouse_pos: Vector2)
 signal header_clicked(column: int)
 signal column_resized(column: int, new_width: float)
-signal progress_changed(row: int, col: int, new_value: float)
-signal cell_edited(row: int, col: int, old_value: Variant, new_value: Variant)
+signal progress_changed(row_id: StringName, col: int, new_value: float)
+signal cell_edited(row_id: StringName, col: int, old_value: Variant, new_value: Variant)
 
 const Namespace := preload("res://addons/yard/editor_only/namespace.gd")
 const ClassUtils := Namespace.ClassUtils
 const EditorThemeUtils := Namespace.EditorThemeUtils
 const AnyIcon := Namespace.AnyIcon
-const YardLogger := preload("res://addons/yard/editor_only/classes/yard_logger.gd")
+const YardLogger := Namespace.YardLogger
 
 const H_ALIGNMENT_MARGINS = {
 	HORIZONTAL_ALIGNMENT_LEFT: 5,
@@ -37,7 +35,6 @@ const INVALID_UID := "uid://<invalid>"
 @export_group("Default color")
 @export var default_font_color: Color = Color(1.0, 1.0, 1.0)
 @export_group("Header")
-#@export var headers: Array[String] = []
 @export var header_height: float = 35.0
 @export var header_color: Color = Color(0.2, 0.2, 0.2)
 @export var header_filter_active_font_color: Color = Color(1.0, 1.0, 0.0)
@@ -71,15 +68,21 @@ var font := get_theme_default_font()
 var mono_font: Font = EditorInterface.get_editor_theme().get_font("font", "CodeEdit")
 var font_size := get_theme_default_font_size()
 
-# Selection and focus variables (public)
-var selected_rows: Array = [] # Indices of the selected rows
-var focused_row: int = -1 # Currently focused row
-var focused_col: int = -1 # Currently focused column
+# Public selection / focus state (key-based)
+var selected_rows: Array[StringName] = []
+var focused_row: StringName = &""
+var focused_col: int = -1
 
-# Internal variables
+# Public sort state
+var sort_column: int = -1
+var sort_ascending: bool = true
+
+# Row storage: key -> cells array (model), ordered key lists (view)
+var _rows: Dictionary[StringName, Array] = { }
+var _base_order: Array[StringName] = [] # insertion order, source for filter
+var _order: Array[StringName] = [] # current visible / sorted order
+
 var _columns: Array[ColumnConfig]
-var _data: Array[Array] = []
-var _full_data: Array = []
 var _total_rows := 0
 var _visible_rows_range: Array[int] = [0, 0]
 var _h_scroll_position := 0
@@ -89,25 +92,23 @@ var _resizing_start_width := 0
 var _mouse_over_divider := -1
 var _divider_width := 5
 var _icon_sort := " ▼ "
-var _last_column_sorted := -1
-var _ascending := true
+
+var _anchor_row: StringName = &""
+
 var _dragging_progress := false
-var _dragging_start_value: Variant # int/float
-var _progress_drag_row := -1
-var _progress_drag_col := -1
+var _dragging_start_value: Variant
+var _progress_drag_row: StringName = &""
+var _progress_drag_col: int = -1
 
-# Resource previews cache management
-var _resource_thumb_cache: Dictionary = { } # key -> Texture2D (or null if failed)
-var _resource_thumb_pending: Dictionary = { } # key -> bool
-
-# Selection and focus variables
-var _previous_sort_selected_rows: Array = [] # Array containing the selected rows before sorting
-var _anchor_row: int = -1 # Anchor row for Shift-based selection
+# Resource preview cache
+var _resource_thumb_cache: Dictionary = { }
+var _resource_thumb_pending: Dictionary = { }
 
 var _pan_delta_accumulation: Vector2 = Vector2.ZERO
 
-# Editing variables
-var _editing_cell := [-1, -1] # row, column
+# Inline editing state
+var _edited_row: StringName = &""
+var _edited_col := -1
 var _text_editor_line_edit: LineEdit
 var _color_editor: Control
 var _resource_editor: EditorResourcePicker
@@ -120,12 +121,13 @@ var _last_click_pos := Vector2.ZERO
 var _double_click_threshold := 400 # milliseconds
 var _click_position_threshold := 5 # pixels
 
-# Filtering variables
+# Column filter
 var _filter_line_edit: LineEdit
-var _filtering_column := -1
+var _filtered_column := -1
 
-# Tooltip variable
-var _tooltip_cell := [-1, -1] # [row, col]
+# Tooltip tracking
+var _tooltip_row: StringName = &""
+var _tooltip_col: int = -1
 
 # Node references
 var _h_scroll: HScrollBar
@@ -139,7 +141,7 @@ func _ready() -> void:
 		EditorInterface.get_resource_previewer().preview_invalidated.connect(_on_resource_previewer_preview_invalidated)
 		set_native_theming()
 
-	self.focus_mode = Control.FOCUS_ALL # For input from keyboard
+	self.focus_mode = Control.FOCUS_ALL
 
 	_setup_editing_components()
 	_setup_filtering_components()
@@ -182,68 +184,60 @@ func _notification(what: int) -> void:
 func _gui_input(event: InputEvent) -> void:
 	if event is InputEventPanGesture:
 		_handle_pan_gesture(event)
-
 	elif event is InputEventMouseMotion:
 		_handle_mouse_motion(event)
-
 	elif event is InputEventMouseButton:
 		_handle_mouse_button(event)
-
-	elif (
-		event is InputEventKey
-		and event.is_pressed()
-		and has_focus()
-	):
+	elif event is InputEventKey and event.is_pressed() and has_focus():
 		_handle_key_input(event as InputEventKey)
 
 
 func _draw() -> void:
 	RenderingServer.canvas_item_clear(_pixelated_canvas_rid)
-	if not is_inside_tree() or _columns.is_empty() or _full_data.is_empty():
+	if not is_inside_tree() or _columns.is_empty() or _order.is_empty():
 		return
 
 	var frozen_w := _get_frozen_width()
-	var scroll_x := frozen_w - _h_scroll_position # screen X of first scrollable column
+	var scroll_x := frozen_w - _h_scroll_position
 	var vis_w := size.x - (_v_scroll.size.x if _v_scroll.visible else 0.0)
 	var y_offset := header_height
 	RenderingServer.canvas_item_set_clip(_pixelated_canvas_rid, true)
 	RenderingServer.canvas_item_set_custom_rect(_pixelated_canvas_rid, true, Rect2(frozen_w, 0.0, maxf(0.0, vis_w - frozen_w), size.y))
 
-	# ── HEADER BACKGROUND ──────────────────────────────────────────────────────
 	draw_rect(Rect2(0, 0, size.x, header_height), header_color)
 
-	# ── PASS 1 : SCROLLABLE COLUMNS ────────────────────────────────────────────
+	# Pass 1: scrollable columns
 	_draw_header_column_range(n_frozen_columns, _columns.size(), scroll_x, frozen_w, vis_w)
 
-	for row in range(_visible_rows_range[0], _visible_rows_range[1]):
-		if row >= _total_rows:
+	for row_idx in range(_visible_rows_range[0], _visible_rows_range[1]):
+		if row_idx >= _total_rows:
 			continue
-		var row_y := y_offset + (row - _visible_rows_range[0]) * row_height
-		var bg := alternate_row_color if row % 2 == 1 else row_color
+		var row := _order[row_idx]
+		var row_y := y_offset + (row_idx - _visible_rows_range[0]) * row_height
+		var bg := alternate_row_color if row_idx % 2 == 1 else row_color
 		draw_rect(Rect2(0, row_y, vis_w, row_height), bg)
 		if selected_rows.has(row):
 			draw_rect(Rect2(0, row_y, vis_w, row_height - 1), selected_row_back_color)
 		draw_line(Vector2(0, row_y + row_height), Vector2(vis_w, row_y + row_height), grid_color)
 		_draw_cells_column_range(row, row_y, n_frozen_columns, _columns.size(), scroll_x, frozen_w, vis_w)
 
-	# ── PASS 2 : FROZEN COLUMNS (drawn on top) ─────────────────────────────────
+	# Pass 2: frozen columns drawn on top
 	if n_frozen_columns > 0:
-		for row in range(_visible_rows_range[0], _visible_rows_range[1]):
-			if row >= _total_rows:
+		for row_idx in range(_visible_rows_range[0], _visible_rows_range[1]):
+			if row_idx >= _total_rows:
 				continue
-			var row_y := y_offset + (row - _visible_rows_range[0]) * row_height
-			var bg := alternate_row_color if row % 2 == 1 else row_color
+			var row := _order[row_idx]
+			var row_y := y_offset + (row_idx - _visible_rows_range[0]) * row_height
+			var bg := alternate_row_color if row_idx % 2 == 1 else row_color
 			draw_rect(Rect2(0, row_y, frozen_w, row_height), bg)
 			if selected_rows.has(row):
 				draw_rect(Rect2(0, row_y, frozen_w, row_height - 1), selected_row_back_color)
 			draw_line(Vector2(0, row_y + row_height), Vector2(frozen_w, row_y + row_height), grid_color)
 			_draw_cells_column_range(row, row_y, 0, n_frozen_columns, 0.0, 0.0, frozen_w)
 
-		# Frozen header on top of scrollable header
 		draw_rect(Rect2(0, 0, frozen_w, header_height), header_color)
 		_draw_header_column_range(0, n_frozen_columns, 0.0, 0.0, vis_w)
 
-		# Separator shadow at the frozen/scrollable boundary
 		var separator_bottom := header_height + mini(_total_rows, _visible_rows_range[1] - _visible_rows_range[0]) * row_height
 		draw_line(Vector2(frozen_w, 0), Vector2(frozen_w, separator_bottom), grid_color.darkened(0.2), 2.0)
 
@@ -254,7 +248,6 @@ func _draw() -> void:
 
 func set_native_theming(delay: int = 0) -> void:
 	if delay != 0 and is_inside_tree():
-		# Useful because the editor theme isn't instantly changed
 		await get_tree().create_timer(delay).timeout
 
 	var root := EditorInterface.get_base_control()
@@ -298,27 +291,88 @@ func get_column(index: int) -> ColumnConfig:
 	return _columns[index] if index in range(_columns.size()) else null
 
 
-func set_data(new_data: Array) -> void:
-	# Store a full copy of the data as the master list
-	_full_data = new_data.duplicate(true)
-	# The view (_data) contains references to rows in the master list
-	_data = _full_data.duplicate(false)
+func get_column_count() -> int:
+	return _columns.size()
 
-	_total_rows = _data.size()
-	_visible_rows_range = [0, min(_total_rows, floori(self.size.y / row_height) if row_height > 0 else 0)]
 
-	selected_rows.clear()
+## Replace all rows. Preserves focused_row and selected_rows for keys that still exist.
+## Preserves the current sort: re-applies it after rebuilding _order.
+func set_data(rows: Array, row_ids: Array[StringName]) -> void:
+	_rows.clear()
+	_base_order.clear()
+	for i in row_ids.size():
+		var row := row_ids[i]
+		_rows[row] = rows[i].duplicate() if i < rows.size() else []
+		_base_order.append(row)
+	_order = _base_order.duplicate()
+
+	_total_rows = _order.size()
+	_visible_rows_range = [0, min(_total_rows, floori(size.y / row_height) if row_height > 0 else 0)]
+
+	# Pad short rows
+	for row in _order:
+		var row_data: Array = _rows[row]
+		while row_data.size() < _columns.size():
+			row_data.append(CELL_INVALID)
+
+	# Preserve selection / focus for rows that still exist
+	var kept_rows: Array[StringName] = []
+	for row in selected_rows:
+		if _rows.has(row):
+			kept_rows.append(row)
+	selected_rows = kept_rows
+
+	if not _rows.has(focused_row):
+		focused_row = &""
+		focused_col = -1
+	if not _rows.has(_anchor_row):
+		_anchor_row = &""
+
 	_resource_thumb_cache.clear()
 	_resource_thumb_pending.clear()
-	_anchor_row = -1
-	focused_row = -1
-	focused_col = -1
 
-	var blank: Variant = CELL_INVALID
-	for row_data_item: Array in _data:
-		while row_data_item.size() < _columns.size():
-			row_data_item.append(blank)
+	_update_scrollbars()
+	queue_redraw()
 
+
+## Update a single row in place without rebuilding the full dataset.
+func update_row(row: StringName, cells: Array) -> void:
+	if not _rows.has(row):
+		return
+	_rows[row] = cells.duplicate()
+	while _rows[row].size() < _columns.size():
+		_rows[row].append(CELL_INVALID)
+	queue_redraw()
+
+
+## Append a new row. No-op if the row already exists.
+func add_row(row: StringName, cells: Array) -> void:
+	if _rows.has(row):
+		return
+	_rows[row] = cells.duplicate()
+	while _rows[row].size() < _columns.size():
+		_rows[row].append(CELL_INVALID)
+	_base_order.append(row)
+	_order.append(row)
+	_total_rows = _order.size()
+	_update_scrollbars()
+	queue_redraw()
+
+
+## Remove a row by key. Clears selection/focus if they pointed to it.
+func remove_row(row: StringName) -> void:
+	if not _rows.has(row):
+		return
+	_rows.erase(row)
+	_base_order.erase(row)
+	_order.erase(row)
+	selected_rows.erase(row)
+	if focused_row == row:
+		focused_row = &""
+		focused_col = -1
+	if _anchor_row == row:
+		_anchor_row = &""
+	_total_rows = _order.size()
 	_update_scrollbars()
 	queue_redraw()
 
@@ -327,15 +381,19 @@ func ordering_data(column_index: int, ascending: bool = true) -> void:
 	if not get_column(column_index):
 		return
 	_finish_editing(false)
-	_last_column_sorted = column_index
-	_store_selected_rows()
+	sort_column = column_index
+	sort_ascending = ascending
 	var column := get_column(column_index)
 	_icon_sort = " ▼ " if ascending else " ▲ "
 
-	_data.sort_custom(
-		func(a: Array, b: Array) -> bool:
-			var ka: Variant = _key_for_sort(a[column_index], column)
-			var kb: Variant = _key_for_sort(b[column_index], column)
+	_order.sort_custom(
+		func(a: StringName, b: StringName) -> bool:
+			var a_cells: Array = _rows.get(a, [])
+			var b_cells: Array = _rows.get(b, [])
+			var va: Variant = a_cells[column_index] if column_index < a_cells.size() else null
+			var vb: Variant = b_cells[column_index] if column_index < b_cells.size() else null
+			var ka: Variant = _key_for_sort(va, column)
+			var kb: Variant = _key_for_sort(vb, column)
 			if ka == null and kb == null:
 				return false
 			if ka == null:
@@ -353,31 +411,32 @@ func ordering_data(column_index: int, ascending: bool = true) -> void:
 			return str(ka) < str(kb) if ascending else str(ka) > str(kb)
 	)
 
-	_restore_selected_rows()
 	queue_redraw()
 
 
-func update_cell(row: int, col: int, value: Variant) -> void:
-	if row >= 0 and row < _data.size() and col >= 0 and col < _columns.size():
-		while _data[row].size() <= col:
-			_data[row].append("")
-		_data[row][col] = value
-		queue_redraw()
+func update_cell(row: StringName, col: int, value: Variant) -> void:
+	if not _rows.has(row) or col < 0 or col >= _columns.size():
+		return
+	while _rows[row].size() <= col:
+		_rows[row].append(CELL_INVALID)
+	_rows[row][col] = value
+	queue_redraw()
 
 
-func get_cell_value(row: int, col: int) -> Variant:
-	if row < 0 or row >= _data.size() or col < 0 or col >= _data[row].size():
+func get_cell_value(row: StringName, col: int) -> Variant:
+	if not _rows.has(row) or col < 0 or col >= _rows[row].size():
 		return null
-	var raw: Variant = _data[row][col]
+	var raw: Variant = _rows[row][col]
 	if is_cell_invalid(row, col):
 		return raw
-	if get_column(col).is_numeric_column() and not _is_numeric_value(raw):
+	if get_column(col) and get_column(col).is_numeric_column() and not _is_numeric_value(raw):
 		return 0
 	return raw
 
 
-func set_selected_cell(row: int, col: int) -> void:
-	if row >= 0 and row < _total_rows and col >= 0 and col < _columns.size():
+func set_selected_cell(row: StringName, col: int) -> void:
+	var idx := _order.find(row)
+	if row != &"" and idx >= 0 and col >= 0 and col < _columns.size():
 		focused_row = row
 		focused_col = col
 		selected_rows.clear()
@@ -386,34 +445,46 @@ func set_selected_cell(row: int, col: int) -> void:
 		_ensure_row_visible(row)
 		_ensure_col_visible(col)
 		queue_redraw()
-	else: # Invalid selection, clear everything
-		focused_row = -1
+	else:
+		focused_row = &""
 		focused_col = -1
 		selected_rows.clear()
-		_anchor_row = -1
+		_anchor_row = &""
 		queue_redraw()
 	cell_selected.emit(focused_row, focused_col)
 
 
 func select_all_rows() -> void:
-	if not _total_rows > 0:
+	if _order.is_empty():
 		return
-
-	selected_rows = range(_total_rows)
-	if focused_row == -1:
-		focused_row = 0
-		_anchor_row = 0
+	selected_rows = _order.duplicate()
+	if focused_row == &"":
+		focused_row = _order[0]
+		_anchor_row = _order[0]
 		focused_col = 0 if _columns.size() > 0 else -1
 	else:
 		_anchor_row = focused_row
-
 	_ensure_row_visible(focused_row)
 	_ensure_col_visible(focused_col)
 
 
-func is_cell_invalid(row: int, col: int) -> bool:
-	var raw: Variant = _data[row][col]
+func is_cell_invalid(row: StringName, col: int) -> bool:
+	if not _rows.has(row) or col >= _rows[row].size():
+		return false
+	var raw: Variant = _rows[row][col]
 	return raw is String and raw == CELL_INVALID
+
+
+## Returns the rows currently visible (after sort/filter), in display order.
+## /!\ These are not the rows in view (when there is overflow + HScrollbar)
+func get_displayed_rows() -> Array[StringName]:
+	return _order.duplicate()
+
+
+## Call after changing n_frozen_columns or other layout properties.
+func refresh_layout() -> void:
+	_update_scrollbars()
+	queue_redraw()
 
 #endregion
 
@@ -438,7 +509,7 @@ func _setup_editing_components() -> void:
 		header_height = _text_editor_line_edit.size.y
 		row_height = _text_editor_line_edit.size.y
 
-	# TODO: Make Inner class instead of packed scene, for portability
+	# TODO: Make inner class instead of packed scene, for portability
 	_color_editor = preload("uid://cuhed17jgms48").instantiate()
 	_color_editor.color_selected.connect(_on_color_editor_color_selected)
 	_color_editor.canceled.connect(_on_color_editor_canceled)
@@ -485,7 +556,6 @@ func _update_scrollbars() -> void:
 	var visible_width := size.x - (_v_scroll.size.x if _v_scroll.visible else 0.)
 	var visible_height := size.y - (_h_scroll.size.y if _h_scroll.visible else 0.) - header_height
 
-	# H-scroll covers only the scrollable (non-frozen) columns
 	var frozen_w := _get_frozen_width()
 	var visible_scrollable_w := visible_width - frozen_w
 	var total_scrollable_w := 0.0
@@ -519,25 +589,7 @@ func _is_numeric_value(value: Variant) -> bool:
 	return str_val.is_valid_float() or str_val.is_valid_int()
 
 
-func _store_selected_rows() -> void:
-	if (selected_rows.size() == 0):
-		return
-	_previous_sort_selected_rows.clear()
-	for index in range(selected_rows.size()):
-		_previous_sort_selected_rows.append(_data[selected_rows[index]])
-
-
-func _restore_selected_rows() -> void:
-	if (_previous_sort_selected_rows.size() == 0):
-		return
-	selected_rows.clear()
-	for index in range(_previous_sort_selected_rows.size()):
-		var idx := _data.find(_previous_sort_selected_rows[index])
-		if (idx >= 0):
-			selected_rows.append(idx)
-
-
-func _start_cell_editing(row: int, col: int) -> void:
+func _start_cell_editing(row: StringName, col: int) -> void:
 	var column := get_column(col)
 	if is_cell_invalid(row, col):
 		return
@@ -554,40 +606,42 @@ func _start_cell_editing(row: int, col: int) -> void:
 		_open_text_editor(row, col)
 	else:
 		YardLogger.warn("There is no editor for this type of cell.")
-	# NB: boolean cells are toggled using single click
 
 
-func _open_text_editor(row: int, col: int) -> void:
+func _open_text_editor(row: StringName, col: int) -> void:
 	var cell_rect := _get_cell_rect(row, col)
 	if not cell_rect:
 		return
 
 	var cell_value: Variant = get_cell_value(row, col)
-	_editing_cell = [row, col]
+	_edited_row = row
+	_edited_col = col
 	_text_editor_line_edit.position = cell_rect.position
 	_text_editor_line_edit.size = cell_rect.size
-	_text_editor_line_edit.text = str(cell_value) if get_cell_value(row, col) != null else ""
+	_text_editor_line_edit.text = str(cell_value) if cell_value != null else ""
 	_text_editor_line_edit.alignment = get_column(col).h_alignment
 	_text_editor_line_edit.show()
 	_text_editor_line_edit.grab_focus()
 	_text_editor_line_edit.select_all()
 
 
-func _open_color_editor(row: int, col: int) -> void:
+func _open_color_editor(row: StringName, col: int) -> void:
 	var cell_rect := _get_cell_rect(row, col)
 	if not cell_rect:
 		return
 
 	var cell_value: Color = get_cell_value(row, col)
-	_editing_cell = [row, col]
+	_edited_row = row
+	_edited_col = col
 	_color_editor.position = cell_rect.get_center() + global_position
 	_color_editor.color = cell_value
 	_color_editor.show()
 	_color_editor.grab_focus()
 
 
-func _open_resource_editor(row: int, col: int) -> void:
-	_editing_cell = [row, col]
+func _open_resource_editor(row: StringName, col: int) -> void:
+	_edited_row = row
+	_edited_col = col
 	var column := get_column(col)
 	_resource_editor.edited_resource = null
 	_resource_editor.base_type = "Resource"
@@ -602,8 +656,9 @@ func _open_resource_editor(row: int, col: int) -> void:
 			break
 
 
-func _open_path_editor(row: int, col: int) -> void:
-	_editing_cell = [row, col]
+func _open_path_editor(row: StringName, col: int) -> void:
+	_edited_row = row
+	_edited_col = col
 	var cell_value: String = get_cell_value(row, col)
 	var column := get_column(col)
 	if column.property_hint in [PROPERTY_HINT_FILE, PROPERTY_HINT_FILE_PATH]:
@@ -619,8 +674,9 @@ func _open_path_editor(row: int, col: int) -> void:
 	_path_editor.popup_centered_ratio(0.55)
 
 
-func _open_enum_editor(row: int, col: int) -> void:
-	_editing_cell = [row, col]
+func _open_enum_editor(row: StringName, col: int) -> void:
+	_edited_row = row
+	_edited_col = col
 	var current_value: Variant = get_cell_value(row, col)
 	var column := get_column(col)
 	var is_numeric := column.is_numeric_column()
@@ -649,20 +705,21 @@ func _open_enum_editor(row: int, col: int) -> void:
 
 
 func _finish_editing(save_changes: bool = true) -> void:
-	if _editing_cell[0] == -1 and _editing_cell[1] == -1:
+	if _edited_row == &"" and _edited_col == -1:
 		return
 
 	if save_changes:
-		var column := get_column(_editing_cell[1])
-		var old_value: Variant = get_cell_value.callv(_editing_cell)
+		var column := get_column(_edited_col)
+		var old_value: Variant = get_cell_value(_edited_row, _edited_col)
 		var new_value: Variant = _get_editor_value_for_column(column)
 		if typeof(new_value) == column.type:
 			if column.is_path_column() and column.property_hint == PROPERTY_HINT_FILE:
 				new_value = ResourceUID.path_to_uid(new_value)
-			update_cell(_editing_cell[0], _editing_cell[1], new_value)
-			cell_edited.emit(_editing_cell[0], _editing_cell[1], old_value, new_value)
+			update_cell(_edited_row, _edited_col, new_value)
+			cell_edited.emit(_edited_row, _edited_col, old_value, new_value)
 
-	_editing_cell = [-1, -1]
+	_edited_row = &""
+	_edited_col = -1
 	_text_editor_line_edit.hide()
 	_color_editor.hide()
 	queue_redraw()
@@ -694,19 +751,19 @@ func _get_editor_value_for_column(column: ColumnConfig) -> Variant:
 	return null
 
 
-func _get_cell_rect(row: int, col: int) -> Rect2:
-	if row < _visible_rows_range[0] or row >= _visible_rows_range[1] or col >= _columns.size():
+func _get_cell_rect(row: StringName, col: int) -> Rect2:
+	var row_idx := _order.find(row)
+	if row_idx < _visible_rows_range[0] or row_idx >= _visible_rows_range[1] or col >= _columns.size():
 		return Rect2()
 	var cell_x := _get_col_x_pos(col)
 	var vis_w := size.x - (_v_scroll.size.x if _v_scroll.visible else 0.)
 	if cell_x + get_column(col).current_width <= 0 or cell_x >= vis_w:
 		return Rect2()
-	var row_y := header_height + (row - _visible_rows_range[0]) * row_height
+	var row_y := header_height + (row_idx - _visible_rows_range[0]) * row_height
 	return Rect2(cell_x, row_y, get_column(col).current_width, row_height)
 
 
-## Dispatches drawing of a single data cell to the correct typed draw function.
-func _dispatch_cell_draw(cell_rect: Rect2, row: int, col_idx: int) -> void:
+func _dispatch_cell_draw(cell_rect: Rect2, row: StringName, col_idx: int) -> void:
 	var col := get_column(col_idx)
 	if is_cell_invalid(row, col_idx):
 		_draw_cell_invalid(cell_rect, row, col_idx)
@@ -728,7 +785,6 @@ func _dispatch_cell_draw(cell_rect: Rect2, row: int, col_idx: int) -> void:
 		_draw_cell_text(cell_rect, row, col_idx)
 
 
-## Draws a single header cell (borders, text, sort icon, resize divider).
 func _draw_header_cell(col_idx: int, cell_x: float, vis_w: float) -> void:
 	var column := get_column(col_idx)
 	draw_line(Vector2(cell_x, 0), Vector2(cell_x, header_height), grid_color)
@@ -740,9 +796,9 @@ func _draw_header_cell(col_idx: int, cell_x: float, vis_w: float) -> void:
 
 	var header_text := column.header
 	var font_color := default_font_color
-	if col_idx == _filtering_column:
+	if col_idx == _filtered_column:
 		font_color = header_filter_active_font_color
-		header_text += " (" + str(_data.size()) + ")"
+		header_text += " (" + str(_order.size()) + ")"
 
 	var header_alignment := HORIZONTAL_ALIGNMENT_LEFT
 	var x_margin: int = H_ALIGNMENT_MARGINS.get(header_alignment)
@@ -757,7 +813,7 @@ func _draw_header_cell(col_idx: int, cell_x: float, vis_w: float) -> void:
 		font_color,
 	)
 
-	if col_idx == _last_column_sorted:
+	if col_idx == sort_column:
 		var text_size := font.get_string_size(header_text, header_alignment, column.current_width, font_size)
 		var icon_align := (
 			HORIZONTAL_ALIGNMENT_RIGHT
@@ -774,7 +830,6 @@ func _draw_header_cell(col_idx: int, cell_x: float, vis_w: float) -> void:
 			font_color,
 		)
 
-	# Resize divider — every column except the last one
 	var divider_x := cell_x + column.current_width
 	if col_idx < _columns.size() - 1 and divider_x < vis_w:
 		draw_line(
@@ -785,7 +840,6 @@ func _draw_header_cell(col_idx: int, cell_x: float, vis_w: float) -> void:
 		)
 
 
-## Draws header cells for columns [col_from, col_to), clipped to [clip_left, vis_w).
 func _draw_header_column_range(col_from: int, col_to: int, start_x: float, clip_left: float, vis_w: float) -> void:
 	var hx := start_x
 	for col_idx in range(col_from, col_to):
@@ -795,9 +849,7 @@ func _draw_header_column_range(col_from: int, col_to: int, start_x: float, clip_
 		hx += col.current_width
 
 
-## Draws data cells for columns [col_from, col_to) for one row, clipped to [clip_left, vis_w).
-## Also draws the table's right border when col_to is the last column.
-func _draw_cells_column_range(row: int, row_y: float, col_from: int, col_to: int, start_x: float, clip_left: float, vis_w: float) -> void:
+func _draw_cells_column_range(row: StringName, row_y: float, col_from: int, col_to: int, start_x: float, clip_left: float, vis_w: float) -> void:
 	var col_x := start_x
 	for col_idx in range(col_from, col_to):
 		var col := get_column(col_idx)
@@ -808,12 +860,11 @@ func _draw_cells_column_range(row: int, row_y: float, col_from: int, col_to: int
 			if row == focused_row and col_idx == focused_col:
 				draw_rect(cell_rect.grow_individual(-1, -1, -2, -2), selected_cell_back_color, false, 2.0)
 		col_x += col.current_width
-	# Right border of the last column in the whole table
 	if col_to == _columns.size() and col_x <= vis_w and col_x > clip_left:
 		draw_line(Vector2(col_x, row_y), Vector2(col_x, row_y + row_height), grid_color)
 
 
-func _draw_cell_progress(rect: Rect2, row: int, col: int) -> void:
+func _draw_cell_progress(rect: Rect2, row: StringName, col: int) -> void:
 	var cell_value: float = get_cell_value(row, col)
 	var range_cfg := get_column(col).range_config
 	var progress: float = inverse_lerp(range_cfg.get(&"min"), range_cfg.get(&"max"), cell_value)
@@ -838,8 +889,8 @@ func _draw_cell_progress(rect: Rect2, row: int, col: int) -> void:
 	draw_rect(bar, progress_border_color, false, 1.0 * EditorThemeUtils.scale)
 
 
-func _draw_cell_bool(rect: Rect2, row: int, col: int) -> void:
-	var cell_value: Variant = _data[row][col]
+func _draw_cell_bool(rect: Rect2, row: StringName, col: int) -> void:
+	var cell_value: Variant = get_cell_value(row, col)
 	if cell_value is not bool:
 		_draw_cell_text(rect, row, col)
 		return
@@ -855,7 +906,7 @@ func _draw_cell_bool(rect: Rect2, row: int, col: int) -> void:
 	draw_texture(icon, pos)
 
 
-func _draw_cell_color(rect: Rect2, row: int, col: int) -> void:
+func _draw_cell_color(rect: Rect2, row: StringName, col: int) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	if cell_value is not Color:
 		_draw_cell_text(rect, row, col)
@@ -868,7 +919,6 @@ func _draw_cell_color(rect: Rect2, row: int, col: int) -> void:
 
 	var border_alpha := 0.65 if color.a < 0.25 else 0.35
 
-	# Checkerboard background to visualize transparency
 	if color.a < 1.0:
 		var tile := 6.0
 		var x0 := inner.position.x
@@ -892,7 +942,7 @@ func _draw_cell_color(rect: Rect2, row: int, col: int) -> void:
 	draw_rect(inner, Color(1, 1, 1, border_alpha), false, 1.0)
 
 
-func _draw_cell_resource(rect: Rect2, row: int, col: int) -> void:
+func _draw_cell_resource(rect: Rect2, row: StringName, col: int) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	if cell_value is not Resource:
 		_draw_cell_text(rect, row, col, tr("<empty>"))
@@ -920,7 +970,7 @@ func _draw_cell_resource(rect: Rect2, row: int, col: int) -> void:
 	_draw_cell_text(text_rect, row, col, label)
 
 
-func _draw_cell_path(rect: Rect2, row: int, col: int) -> void:
+func _draw_cell_path(rect: Rect2, row: StringName, col: int) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	var is_invalid_uid: bool = cell_value == INVALID_UID
 	if not get_column(col).property_hint == PROPERTY_HINT_FILE:
@@ -955,7 +1005,6 @@ func _draw_cell_path(rect: Rect2, row: int, col: int) -> void:
 func _draw_filtered_texture_rect(texture: Texture2D, rect: Rect2) -> void:
 	var ratio := rect.size / texture.get_size()
 	if minf(ratio.x, ratio.y) > 1.5 * EditorInterface.get_editor_scale() and rect.end.x > _get_frozen_width():
-		# Probably pixel-art. Heuristic similar to godotengine/godot#67426
 		if texture is AtlasTexture:
 			RenderingServer.canvas_item_add_texture_rect_region(_pixelated_canvas_rid, rect, texture.get_rid(), texture.region)
 		else:
@@ -964,7 +1013,7 @@ func _draw_filtered_texture_rect(texture: Texture2D, rect: Rect2) -> void:
 		draw_texture_rect(texture, rect, false)
 
 
-func _draw_cell_text(rect: Rect2, row: int, col: int, text_override: String = "", color_override: Color = Color.TRANSPARENT) -> void:
+func _draw_cell_text(rect: Rect2, row: StringName, col: int, text_override: String = "", color_override: Color = Color.TRANSPARENT) -> void:
 	var cell_value := str(get_cell_value(row, col))
 
 	var column := get_column(col)
@@ -996,7 +1045,7 @@ func _draw_cell_text(rect: Rect2, row: int, col: int, text_override: String = ""
 	)
 
 
-func _draw_cell_enum(rect: Rect2, row: int, col: int) -> void:
+func _draw_cell_enum(rect: Rect2, row: StringName, col: int) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	var column := get_column(col)
 	var value_str := ""
@@ -1025,11 +1074,11 @@ func _draw_cell_enum(rect: Rect2, row: int, col: int) -> void:
 	)
 
 
-func _draw_cell_invalid(rect: Rect2, _row: int, _col: int) -> void:
+func _draw_cell_invalid(rect: Rect2, _row: StringName, _col: int) -> void:
 	draw_rect(rect, invalid_cell_color, true)
 
 
-func _draw_cell_collection(rect: Rect2, row: int, col: int) -> void:
+func _draw_cell_collection(rect: Rect2, row: StringName, col: int) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	if cell_value is not Array and cell_value is not Dictionary:
 		_draw_cell_text(rect, row, col)
@@ -1136,12 +1185,12 @@ func _fit_texture_rect(texture: Texture2D, container: Rect2, anchor_to_left := f
 
 
 func _start_filtering(col_idx: int) -> void:
-	if _filtering_column == col_idx and _filter_line_edit.visible:
-		return # Already in filter mode on this column
+	if _filtered_column == col_idx and _filter_line_edit.visible:
+		return
 
 	var col_x := _get_col_x_pos(col_idx)
 	var header_rect := Rect2(col_x, 0, get_column(col_idx).current_width, header_height)
-	_filtering_column = col_idx
+	_filtered_column = col_idx
 	_filter_line_edit.position = header_rect.position + Vector2(1, 1)
 	_filter_line_edit.size = header_rect.size - Vector2(2, 2)
 	_filter_line_edit.text = ""
@@ -1154,30 +1203,35 @@ func _apply_filter(search_key: String) -> void:
 		return
 
 	_filter_line_edit.visible = false
-	if _filtering_column == -1:
+	if _filtered_column == -1:
 		return
 
 	if search_key.is_empty():
-		# If the key is empty, restore all data (remove the filter)
-		_data = _full_data.duplicate(false)
-		_filtering_column = -1
+		_order = _base_order.duplicate()
+		_filtered_column = -1
 	else:
-		var filtered_data: Array[Array] = []
+		_order.clear()
 		var key_lower := search_key.to_lower()
-		for row_data: Array in _full_data:
-			if _filtering_column < row_data.size() and row_data[_filtering_column] != null:
-				var cell_value := str(row_data[_filtering_column]).to_lower()
+		for row in _base_order:
+			var row_data: Array = _rows.get(row, [])
+			if _filtered_column < row_data.size() and row_data[_filtered_column] != null:
+				var cell_value := str(row_data[_filtered_column]).to_lower()
 				if cell_value.contains(key_lower):
-					filtered_data.append(row_data) # Adds the reference
-		_data = filtered_data
+					_order.append(row)
 
-	# Reset the view
-	_total_rows = _data.size()
+	_total_rows = _order.size()
 	_v_scroll.value = 0
-	selected_rows.clear()
-	_previous_sort_selected_rows.clear()
-	focused_row = -1
-	_last_column_sorted = -1 # Reset visual sorting
+
+	# Keep selection only for rows still visible after filter
+	var kept: Array[StringName] = []
+	for row in selected_rows:
+		if _order.has(row):
+			kept.append(row)
+	selected_rows = kept
+	if not _order.has(focused_row):
+		focused_row = &""
+
+	sort_column = -1
 
 	_update_scrollbars()
 	queue_redraw()
@@ -1194,7 +1248,7 @@ func _key_for_sort(value: Variant, column: ColumnConfig) -> Variant:
 		var c := Color(value)
 		return [c.h, c.s, c.v, c.a]
 	if column.is_resource_column():
-		if value is Resource: # might be <empty>
+		if value is Resource:
 			var r: Resource = value
 			if r.resource_path != "":
 				return r.resource_path.get_file()
@@ -1203,8 +1257,6 @@ func _key_for_sort(value: Variant, column: ColumnConfig) -> Variant:
 	return str(value)
 
 
-## Returns the column index under screen x, or -1 if none.
-## Frozen columns take priority: a click in the frozen zone always hits a frozen column.
 func _get_col_at_x(x: float) -> int:
 	var frozen_w := _get_frozen_width()
 	var col_x := 0.0
@@ -1225,7 +1277,6 @@ func _get_col_at_x(x: float) -> int:
 	return -1
 
 
-## Returns the row index under y, or -1 if above the header or out of range.
 func _get_row_at_y(y: float) -> int:
 	if y < header_height or row_height <= 0:
 		return -1
@@ -1233,7 +1284,6 @@ func _get_row_at_y(y: float) -> int:
 	return row if row < _total_rows else -1
 
 
-## Returns the baseline Y for drawing text vertically centered in a cell.
 func _get_text_baseline_y(cell_y: float, cell_height: float = -1.0) -> float:
 	var h := cell_height if cell_height >= 0.0 else row_height
 	var ascent := font.get_ascent(font_size)
@@ -1241,7 +1291,6 @@ func _get_text_baseline_y(cell_y: float, cell_height: float = -1.0) -> float:
 	return cell_y + (h + ascent - descent) / 2.0
 
 
-## Total width of frozen (pinned) columns.
 func _get_frozen_width() -> float:
 	var w := 0.0
 	for i in mini(n_frozen_columns, _columns.size()):
@@ -1249,8 +1298,6 @@ func _get_frozen_width() -> float:
 	return w
 
 
-## Screen X of the left edge of column col_idx, accounting for freeze and scroll.
-## Frozen columns sit at fixed positions; scrollable columns follow the h-scroll.
 func _get_col_x_pos(col_idx: int) -> float:
 	if col_idx < n_frozen_columns:
 		var x := 0.0
@@ -1271,7 +1318,6 @@ func _check_mouse_over_divider(mouse_pos: Vector2) -> void:
 	if mouse_pos.y < header_height:
 		for col_idx in _columns.size():
 			var divider_x := _get_col_x_pos(col_idx) + get_column(col_idx).current_width
-			# Skip dividers of scrollable columns hidden behind the frozen zone
 			if col_idx >= n_frozen_columns and divider_x <= _get_frozen_width():
 				continue
 			var divider_rect := Rect2(divider_x - _divider_width / 2.0, 0, _divider_width, header_height)
@@ -1284,59 +1330,65 @@ func _check_mouse_over_divider(mouse_pos: Vector2) -> void:
 
 
 func _update_tooltip(mouse_pos: Vector2) -> void:
-	var current_cell := [-1, -1]
+	var new_row: StringName = &""
+	var new_col := -1
 	var new_tooltip := ""
 
 	var col_idx := _get_col_at_x(mouse_pos.x)
 	if col_idx == -1:
-		if current_cell != _tooltip_cell:
-			_tooltip_cell = current_cell
+		if new_row != _tooltip_row or new_col != _tooltip_col:
+			_tooltip_row = new_row
+			_tooltip_col = new_col
 			self.tooltip_text = new_tooltip
 		return
 
 	if mouse_pos.y < header_height:
 		new_tooltip = get_column(col_idx).header
-		current_cell = [-2, col_idx]
+		new_row = &"<header>"
+		new_col = col_idx
 	else:
 		var row_idx := _get_row_at_y(mouse_pos.y)
 		if row_idx >= 0:
+			new_row = _order[row_idx]
+			new_col = col_idx
 			var column := get_column(col_idx)
 			if not column.is_range_column() and not column.is_boolean_column():
-				new_tooltip = str(get_cell_value(row_idx, col_idx))
-			current_cell = [row_idx, col_idx]
+				new_tooltip = str(get_cell_value(new_row, col_idx))
 
-	if current_cell != _tooltip_cell:
-		_tooltip_cell = current_cell
+	if new_row != _tooltip_row or new_col != _tooltip_col:
+		_tooltip_row = new_row
+		_tooltip_col = new_col
 		self.tooltip_text = new_tooltip
 
 
 func _is_clicking_progress_bar(mouse_pos: Vector2) -> bool:
-	var row := _get_row_at_y(mouse_pos.y)
+	var row_idx := _get_row_at_y(mouse_pos.y)
 	var col := _get_col_at_x(mouse_pos.x)
-	if -1 in [row, col]:
+	if row_idx < 0 or col == -1:
 		return false
 	return get_column(col).is_range_column()
 
 
-func _toggle_checkbox(row: int, col: int) -> void:
+func _toggle_checkbox(row: StringName, col: int) -> void:
 	var old_val := bool(get_cell_value(row, col))
 	var new_val := !old_val
 	update_cell(row, col, new_val)
 	cell_edited.emit(row, col, old_val, new_val)
 
 
-func _ensure_row_visible(row_idx: int) -> void:
-	if _total_rows == 0 or row_height == 0 or not _v_scroll.visible:
+func _ensure_row_visible(row: StringName) -> void:
+	var row_idx := _order.find(row)
+	if row_idx < 0 or _total_rows == 0 or row_height == 0 or not _v_scroll.visible:
 		return
 
 	var visible_area_height: float = size.y - header_height - (_h_scroll.size.y if _h_scroll.visible else 0.0)
-	var num_visible_rows_in_page := floori(visible_area_height / row_height)
-	var first_fully_visible_row: int = _visible_rows_range[0]
+	var num_visible_rows := floori(visible_area_height / row_height)
+	var first_fully_visible: int = _visible_rows_range[0]
 
-	if row_idx < first_fully_visible_row:
+	if row_idx < first_fully_visible:
 		_v_scroll.value = row_idx * row_height
-	elif row_idx >= first_fully_visible_row + num_visible_rows_in_page:
-		_v_scroll.value = (row_idx - num_visible_rows_in_page + 1) * row_height
+	elif row_idx >= first_fully_visible + num_visible_rows:
+		_v_scroll.value = (row_idx - num_visible_rows + 1) * row_height
 
 	_v_scroll.value = clamp(_v_scroll.value, 0, _v_scroll.max_value)
 
@@ -1345,9 +1397,8 @@ func _ensure_col_visible(col_idx: int) -> void:
 	if _columns.is_empty() or col_idx < 0 or col_idx >= _columns.size() or not _h_scroll.visible:
 		return
 	if col_idx < n_frozen_columns:
-		return # Frozen columns are always visible
+		return
 
-	# Scroll-space: position relative to start of scrollable content
 	var col_scroll_pos := 0.0
 	for i in range(n_frozen_columns, col_idx):
 		col_scroll_pos += get_column(i).current_width
@@ -1374,25 +1425,18 @@ func _handle_pan_gesture(event: InputEventPanGesture) -> void:
 func _handle_mouse_motion(event: InputEventMouseMotion) -> void:
 	var m_pos := event.position
 
-	if (
-		_dragging_progress
-		and _progress_drag_row >= 0
-		and _progress_drag_col >= 0
-	):
+	if _dragging_progress and _progress_drag_row != &"" and _progress_drag_col >= 0:
 		_handle_progress_drag(m_pos)
-
 	elif _resizing_column in range(_columns.size()):
 		var delta_x: float = m_pos.x - _resizing_start_pos
 		var new_width: float = max(
 			_resizing_start_width + delta_x,
 			get_column(_resizing_column).minimum_width,
 		)
-
 		get_column(_resizing_column).current_width = new_width
 		_update_scrollbars()
 		column_resized.emit(_resizing_column, new_width)
 		queue_redraw()
-
 	else:
 		_check_mouse_over_divider(m_pos)
 		_update_tooltip(m_pos)
@@ -1410,7 +1454,6 @@ func _handle_mouse_button(event: InputEventMouseButton) -> void:
 			MOUSE_BUTTON_WHEEL_DOWN:
 				_v_scroll.value = minf(_v_scroll.max_value, _v_scroll.value + _v_scroll.step)
 			MOUSE_BUTTON_WHEEL_LEFT:
-				# Also uses the VScroll's step, as the HScroll doesn't have one
 				_h_scroll.value = maxf(0.0, _h_scroll.value - _v_scroll.step)
 			MOUSE_BUTTON_WHEEL_RIGHT:
 				_h_scroll.value = minf(_h_scroll.max_value, _h_scroll.value + _v_scroll.step)
@@ -1448,7 +1491,8 @@ func _handle_left_press(event: InputEventMouseButton) -> void:
 		_handle_checkbox_click(m_pos)
 		_handle_cell_click(m_pos, event)
 		if _is_clicking_progress_bar(m_pos):
-			_progress_drag_row = _get_row_at_y(m_pos.y)
+			var row_idx := _get_row_at_y(m_pos.y)
+			_progress_drag_row = _order[row_idx]
 			_progress_drag_col = _get_col_at_x(m_pos.x)
 			_dragging_start_value = get_cell_value(_progress_drag_row, _progress_drag_col)
 			_dragging_progress = true
@@ -1466,16 +1510,12 @@ func _handle_left_release() -> void:
 		cell_edited.emit(_progress_drag_row, _progress_drag_col, _dragging_start_value, new_val)
 	_resizing_column = -1
 	_dragging_progress = false
-	_progress_drag_row = -1
+	_progress_drag_row = &""
 	_progress_drag_col = -1
 
 
 func _handle_progress_drag(mouse_pos: Vector2) -> void:
-	if (
-		_progress_drag_row < 0
-		or _progress_drag_col < 0
-		or _progress_drag_col >= _columns.size()
-	):
+	if _progress_drag_row == &"" or _progress_drag_col < 0 or _progress_drag_col >= _columns.size():
 		return
 
 	var margin := 4.0
@@ -1495,59 +1535,60 @@ func _handle_progress_drag(mouse_pos: Vector2) -> void:
 	if not range_cfg.has(&"or_less"):
 		new_progress = max(new_progress, range_cfg.get(&"min"))
 
-	if _progress_drag_row < _data.size() and _progress_drag_col < _data[_progress_drag_row].size():
-		_data[_progress_drag_row][_progress_drag_col] = new_progress
+	if _rows.has(_progress_drag_row) and _progress_drag_col < _rows[_progress_drag_row].size():
+		_rows[_progress_drag_row][_progress_drag_col] = new_progress
 		progress_changed.emit(_progress_drag_row, _progress_drag_col, new_progress)
 		queue_redraw()
 
 
 func _handle_checkbox_click(mouse_pos: Vector2) -> bool:
-	var row := _get_row_at_y(mouse_pos.y)
+	var row_idx := _get_row_at_y(mouse_pos.y)
 	var col := _get_col_at_x(mouse_pos.x)
-	if -1 in [row, col]:
+	if row_idx < 0 or col == -1:
 		return false
-
 	if not get_column(col).is_boolean_column():
 		return false
 
+	var row := _order[row_idx]
 	var rect := _get_cell_rect(row, col)
 	var icon: Texture2D = get_theme_icon(&"checked", &"CheckBox")
 	var icon_rect := Rect2(rect.get_center() - icon.get_size() / 2, icon.get_size())
 	if icon_rect.has_point(mouse_pos):
 		_toggle_checkbox(row, col)
 		return true
-
 	return false
 
 
 func _handle_cell_click(mouse_pos: Vector2, event: InputEventMouseButton) -> void:
-	if _editing_cell[1] >= 0:
-		var column := get_column(_editing_cell[1])
+	if _edited_col >= 0:
+		var column := get_column(_edited_col)
 		var save := not (column.is_resource_column() or column.is_path_column() or column.is_enum_column())
 		_finish_editing(save)
 
-	var clicked_row := _get_row_at_y(mouse_pos.y)
+	var clicked_idx := _get_row_at_y(mouse_pos.y)
 	var clicked_col := _get_col_at_x(mouse_pos.x)
-	if clicked_row < 0 or clicked_col == -1:
+	if clicked_idx < 0 or clicked_col == -1:
 		return
 
+	var clicked_row := _order[clicked_idx]
 	focused_row = clicked_row
 	focused_col = clicked_col
 
-	if event.is_shift_pressed() and _anchor_row != -1:
+	if event.is_shift_pressed() and _anchor_row != &"":
+		var anchor_idx := _order.find(_anchor_row)
 		selected_rows.clear()
-		for i in range(mini(_anchor_row, focused_row), maxi(_anchor_row, focused_row) + 1):
-			selected_rows.append(i)
+		for i in range(mini(anchor_idx, clicked_idx), maxi(anchor_idx, clicked_idx) + 1):
+			selected_rows.append(_order[i])
 	elif event.is_ctrl_pressed() or event.is_meta_pressed():
-		if selected_rows.has(focused_row):
-			selected_rows.erase(focused_row)
+		if selected_rows.has(clicked_row):
+			selected_rows.erase(clicked_row)
 		else:
-			selected_rows.append(focused_row)
-		_anchor_row = focused_row
+			selected_rows.append(clicked_row)
+		_anchor_row = clicked_row
 	else:
 		selected_rows.clear()
-		selected_rows.append(focused_row)
-		_anchor_row = focused_row
+		selected_rows.append(clicked_row)
+		_anchor_row = clicked_row
 
 	cell_selected.emit(focused_row, focused_col)
 	_ensure_col_visible(focused_col)
@@ -1559,8 +1600,9 @@ func _handle_cell_click(mouse_pos: Vector2, event: InputEventMouseButton) -> voi
 
 
 func _handle_right_click(mouse_pos: Vector2) -> void:
-	var clicked_row := _get_row_at_y(mouse_pos.y)
+	var clicked_idx := _get_row_at_y(mouse_pos.y)
 	var clicked_col := _get_col_at_x(mouse_pos.x)
+	var clicked_row := _order[clicked_idx] if clicked_idx >= 0 else &""
 
 	if selected_rows.size() <= 1:
 		set_selected_cell(clicked_row, clicked_col)
@@ -1572,8 +1614,9 @@ func _handle_double_click(mouse_pos: Vector2) -> void:
 	if mouse_pos.y < header_height:
 		return
 
-	var row := _get_row_at_y(mouse_pos.y)
-	if row >= 0:
+	var row_idx := _get_row_at_y(mouse_pos.y)
+	if row_idx >= 0:
+		var row := _order[row_idx]
 		var col := _get_col_at_x(mouse_pos.x)
 		if col != -1:
 			if not (selected_rows.size() == 1 and selected_rows[0] == row and focused_row == row and focused_col == col):
@@ -1589,8 +1632,8 @@ func _handle_header_click(mouse_pos: Vector2) -> void:
 			and mouse_pos.x < col_x + get_column(col_idx).current_width - _divider_width / 2.0
 		):
 			_finish_editing(false)
-			_ascending = not _ascending if _last_column_sorted == col_idx else true
-			ordering_data(col_idx, _ascending)
+			sort_ascending = not sort_ascending if sort_column == col_idx else true
+			ordering_data(col_idx, sort_ascending)
 			header_clicked.emit(col_idx)
 			break
 
@@ -1613,9 +1656,10 @@ func _handle_key_input(event: InputEventKey) -> void:
 	var keycode := event.keycode
 	var is_shift := event.is_shift_pressed()
 	var is_ctrl_cmd := event.is_ctrl_pressed() or event.is_meta_pressed()
-	var is_cell_focused := focused_row != -1 and focused_col != -1
+	var is_cell_focused := focused_row != &"" and focused_col != -1
 
-	var new_row := focused_row
+	var focused_idx := _order.find(focused_row) if focused_row != &"" else -1
+	var new_idx := focused_idx
 	var new_col := focused_col
 
 	match keycode:
@@ -1635,30 +1679,29 @@ func _handle_key_input(event: InputEventKey) -> void:
 				_finalize_key_operation()
 			return
 		KEY_ESCAPE:
-			if selected_rows.is_empty() and focused_row == -1:
+			if selected_rows.is_empty() and focused_row == &"":
 				return
-			set_selected_cell(-1, -1)
-			_previous_sort_selected_rows.clear()
+			set_selected_cell(&"", -1)
 			_finalize_key_operation()
 			return
 		KEY_HOME:
 			if _total_rows == 0:
 				return
-			new_row = 0
+			new_idx = 0
 			new_col = 0 if not _columns.is_empty() else -1
 		KEY_END:
 			if _total_rows == 0:
 				return
-			new_row = _total_rows - 1
+			new_idx = _total_rows - 1
 			new_col = _columns.size() - 1 if not _columns.is_empty() else -1
 		KEY_UP:
 			if not is_cell_focused:
 				return
-			new_row = maxi(0, focused_row - 1)
+			new_idx = maxi(0, focused_idx - 1)
 		KEY_DOWN:
 			if not is_cell_focused:
 				return
-			new_row = mini(_total_rows - 1, focused_row + 1)
+			new_idx = mini(_total_rows - 1, focused_idx + 1)
 		KEY_LEFT:
 			if not is_cell_focused:
 				return
@@ -1670,11 +1713,11 @@ func _handle_key_input(event: InputEventKey) -> void:
 		KEY_PAGEUP:
 			if not is_cell_focused:
 				return
-			new_row = maxi(0, focused_row - _page_row_count())
+			new_idx = maxi(0, focused_idx - _page_row_count())
 		KEY_PAGEDOWN:
 			if not is_cell_focused:
 				return
-			new_row = mini(_total_rows - 1, focused_row + _page_row_count())
+			new_idx = mini(_total_rows - 1, focused_idx + _page_row_count())
 		KEY_SPACE:
 			if not is_cell_focused or not is_ctrl_cmd:
 				return
@@ -1689,14 +1732,15 @@ func _handle_key_input(event: InputEventKey) -> void:
 		_:
 			return
 
+	var new_row := _order[new_idx] if new_idx >= 0 and new_idx < _order.size() else &""
 	var old_row := focused_row
 	var old_col := focused_col
 	focused_row = new_row
 	focused_col = new_col
 
-	_update_selection_after_navigation(old_row, is_shift, is_ctrl_cmd)
+	_update_selection_after_navigation(old_row, focused_idx, is_shift, is_ctrl_cmd)
 
-	if focused_row != -1:
+	if focused_row != &"":
 		_ensure_row_visible(focused_row)
 		_ensure_col_visible(focused_col)
 
@@ -1710,28 +1754,30 @@ func _page_row_count() -> int:
 	return maxi(1, floori((size.y - header_height) / row_height) if row_height > 0 else 10)
 
 
-func _update_selection_after_navigation(old_row: int, is_shift: bool, is_ctrl_cmd: bool) -> void:
+func _update_selection_after_navigation(old_row: StringName, old_idx: int, is_shift: bool, is_ctrl_cmd: bool) -> void:
 	if is_shift:
-		if _anchor_row == -1:
-			_anchor_row = old_row if old_row != -1 else 0
-		if focused_row == -1:
+		if _anchor_row == &"":
+			_anchor_row = old_row if old_row != &"" else (_order[0] if not _order.is_empty() else &"")
+		if focused_row == &"":
 			return
+		var anchor_idx := _order.find(_anchor_row)
+		var focus_idx := _order.find(focused_row)
 		selected_rows.clear()
-		for i in range(mini(_anchor_row, focused_row), maxi(_anchor_row, focused_row) + 1):
+		for i in range(mini(anchor_idx, focus_idx), maxi(anchor_idx, focus_idx) + 1):
 			if i >= 0 and i < _total_rows:
-				selected_rows.append(i)
+				selected_rows.append(_order[i])
 		if selected_rows.size() > 1:
 			multiple_rows_selected.emit(selected_rows)
 	elif is_ctrl_cmd:
-		pass # Move focus only, preserve selection
+		pass
 	else:
-		if focused_row != -1:
+		if focused_row != &"":
 			selected_rows.clear()
 			selected_rows.append(focused_row)
 			_anchor_row = focused_row
 		else:
 			selected_rows.clear()
-			_anchor_row = -1
+			_anchor_row = &""
 
 
 func _finalize_key_operation() -> void:
@@ -1746,7 +1792,7 @@ func _apply_pan_axis(delta: float, scroll: ScrollBar, axis: int) -> void:
 		_pan_delta_accumulation[axis] = 0.0
 	_pan_delta_accumulation[axis] += delta
 	if abs(_pan_delta_accumulation[axis]) >= 1.0:
-		scroll.value += sign(_pan_delta_accumulation[axis]) * _v_scroll.step #scroll.step
+		scroll.value += sign(_pan_delta_accumulation[axis]) * _v_scroll.step
 		_pan_delta_accumulation[axis] -= sign(_pan_delta_accumulation[axis])
 
 #endregion
@@ -1791,7 +1837,6 @@ func _on_enum_editor_index_pressed(idx: int) -> void:
 
 
 func _on_enum_editor_popup_hide() -> void:
-	# for '_on_enum_editor_id_pressed' to trigger first
 	await get_tree().create_timer(0.05).timeout
 	_finish_editing(false)
 
@@ -1808,11 +1853,11 @@ func _on_h_scroll_changed(value: float) -> void:
 
 
 func _on_v_scroll_value_changed(value: float) -> void:
-	if row_height > 0: # Avoid division by zero
+	if row_height > 0:
 		_visible_rows_range[0] = floori(value / row_height)
 		_visible_rows_range[1] = _visible_rows_range[0] + floori((size.y - header_height) / row_height) + 1
 		_visible_rows_range[1] = min(_visible_rows_range[1], _total_rows)
-	else: # Fallback if row_height is not valid
+	else:
 		_visible_rows_range = [0, _total_rows]
 
 	if _text_editor_line_edit.visible:
@@ -1821,7 +1866,6 @@ func _on_v_scroll_value_changed(value: float) -> void:
 
 
 func _on_filter_focus_exited() -> void:
-	# Apply the filter also when the text field loses focus
 	if _filter_line_edit.visible:
 		_apply_filter(_filter_line_edit.text)
 
@@ -1837,7 +1881,6 @@ func _on_editor_settings_changed() -> void:
 
 
 func _on_resource_previewer_preview_invalidated(path: String) -> void:
-	#push_warning("RESOURCE PREVIEW INVALIDATED: %s" % path)
 	if _resource_thumb_cache.has(path):
 		_resource_thumb_cache.erase(path)
 
@@ -1848,11 +1891,10 @@ func _on_resource_cell_thumb_ready(resource_path: String, preview: Texture2D, th
 
 	var tex: Texture2D = thumbnail_preview if thumbnail_preview else preview
 
-	# Fallback to resource class icon
 	if not tex:
 		tex = AnyIcon.get_class_icon(userdata.get(&"class", &"Resource"))
 
-	_resource_thumb_cache[resource_path] = tex # can be null if both are null
+	_resource_thumb_cache[resource_path] = tex
 	_resource_thumb_pending.erase(resource_path)
 
 	await get_tree().create_timer(0.01).timeout
@@ -1967,17 +2009,14 @@ class ColumnConfig:
 		return is_array_column() or is_dictionary_column()
 
 
-	## Array column whose elements are enum values
 	func is_enum_array_column() -> bool:
 		return is_array_column() and hint_string and _is_enum_collection_hint(hint_string)
 
 
-	## Dictionary column whose keys are enum values
 	func is_enum_key_dictionary_column() -> bool:
 		return is_dictionary_column() and hint_string and _is_enum_collection_hint(_dict_key_hint_part())
 
 
-	## Dictionary column whose values are enum values
 	func is_enum_value_dictionary_column() -> bool:
 		return is_dictionary_column() and hint_string and _is_enum_collection_hint(_dict_value_hint_part())
 

--- a/addons/yard/editor_only/ui_scenes/components/dynamic_table.gd
+++ b/addons/yard/editor_only/ui_scenes/components/dynamic_table.gd
@@ -7,13 +7,13 @@
 @tool
 extends Control
 
-signal cell_selected(row_id: StringName, col: int)
+signal cell_selected(row_id: StringName, col: StringName)
 signal multiple_rows_selected(row_ids: Array[StringName])
-signal cell_right_selected(row_id: StringName, col: int, mouse_pos: Vector2)
-signal header_clicked(column: int)
-signal column_resized(column: int, new_width: float)
-signal progress_changed(row_id: StringName, col: int, new_value: float)
-signal cell_edited(row_id: StringName, col: int, old_value: Variant, new_value: Variant)
+signal cell_right_selected(row_id: StringName, col: StringName, mouse_pos: Vector2)
+signal header_clicked(column: StringName)
+signal column_resized(column: StringName, new_width: float)
+signal progress_changed(row_id: StringName, col: StringName, new_value: float)
+signal cell_edited(row_id: StringName, col: StringName, old_value: Variant, new_value: Variant)
 
 const Namespace := preload("res://addons/yard/editor_only/namespace.gd")
 const ClassUtils := Namespace.ClassUtils
@@ -68,70 +68,80 @@ var font := get_theme_default_font()
 var mono_font: Font = EditorInterface.get_editor_theme().get_font("font", "CodeEdit")
 var font_size := get_theme_default_font_size()
 
-# Public selection / focus state (key-based)
+# Public state: selection, focus and sort (row/column keys)
 var selected_rows: Array[StringName] = []
 var focused_row: StringName = &""
-var focused_col: int = -1
-
-# Public sort state
-var sort_column: int = -1
+var focused_col: StringName = &""
+var sort_column: StringName = &""
 var sort_ascending: bool = true
 
-# Row storage: key -> cells array (model), ordered key lists (view)
+# Row model: key -> cells (the data), and the current display order
 var _rows: Dictionary[StringName, Array] = { }
 var _base_order: Array[StringName] = [] # insertion order, source for filter
-var _order: Array[StringName] = [] # current visible / sorted order
-
-var _columns: Array[ColumnConfig]
+var _order: Array[StringName] = [] # current visible filtered / sorted order
 var _total_rows := 0
-var _visible_rows_range: Array[int] = [0, 0]
+var _anchor_row: StringName = &"" # shift-select range anchor
+
+# Column model: the ordered list is both the model and the display order
+# (no column reordering feature exists). The map is a position cache.
+var _columns: Array[ColumnConfig]
+var _column_index_by_id: Dictionary[StringName, int] = { }
+
+# Scrolling
+var _h_scroll: HScrollBar
+var _v_scroll: VScrollBar
 var _h_scroll_position := 0
-var _resizing_column := -1
+var _visible_rows_range: Array[int] = [0, 0]
+
+# Column resizing (dragging a header divider)
+var _resizing_column: StringName = &""
 var _resizing_start_pos := 0
 var _resizing_start_width := 0
 var _mouse_over_divider := -1
 var _divider_width := 5
+
+# Sort icon (header rendering)
 var _icon_sort := " ▼ "
 
-var _anchor_row: StringName = &""
+# Column filter (double-click a header to search within that column)
+var _filter_line_edit: LineEdit
+var _filtered_column: StringName = &""
 
-var _dragging_progress := false
-var _dragging_start_value: Variant
-var _progress_drag_row: StringName = &""
-var _progress_drag_col: int = -1
-
-# Resource preview cache
-var _resource_thumb_cache: Dictionary = { }
-var _resource_thumb_pending: Dictionary = { }
-
-var _pan_delta_accumulation: Vector2 = Vector2.ZERO
-
-# Inline editing state
+# Inline cell editing
 var _edited_row: StringName = &""
-var _edited_col := -1
+var _edited_col: StringName = &""
 var _text_editor_line_edit: LineEdit
 var _color_editor: Control
 var _resource_editor: EditorResourcePicker
 var _path_editor: EditorFileDialog
 var _enum_editor: PopupMenu
 var _enum_editor_last_idx: int = -1
+
+# Click detection (single vs. double click)
 var _double_click_timer: Timer
 var _click_count := 0
 var _last_click_pos := Vector2.ZERO
 var _double_click_threshold := 400 # milliseconds
 var _click_position_threshold := 5 # pixels
 
-# Column filter
-var _filter_line_edit: LineEdit
-var _filtered_column := -1
+# Progress bar dragging
+var _dragging_progress := false
+var _dragging_start_value: Variant
+var _progress_drag_row: StringName = &""
+var _progress_drag_col: StringName = &""
+
+# Resource preview cache (thumbnails for resource / path columns)
+var _resource_thumb_cache: Dictionary = { }
+var _resource_thumb_pending: Dictionary = { }
 
 # Tooltip tracking
 var _tooltip_row: StringName = &""
-var _tooltip_col: int = -1
+var _tooltip_col: StringName = &""
 
-# Node references
-var _h_scroll: HScrollBar
-var _v_scroll: VScrollBar
+# Trackpad / touch pan gesture
+var _pan_delta_accumulation: Vector2 = Vector2.ZERO
+
+# Rendering
 var _pixelated_canvas_rid: RID
 
 
@@ -283,16 +293,25 @@ func set_native_theming(delay: int = 0) -> void:
 
 func set_columns(columns: Array[ColumnConfig]) -> void:
 	_columns = columns
+	_column_index_by_id.clear()
+	for i in _columns.size():
+		_column_index_by_id[_columns[i].identifier] = i
 	_reset_column_widths()
 	queue_redraw()
 
 
-func get_column(index: int) -> ColumnConfig:
-	return _columns[index] if index in range(_columns.size()) else null
+func get_column(col: StringName) -> ColumnConfig:
+	var idx := _column_index_by_id.get(col, -1)
+	return _columns[idx] if idx >= 0 else null
 
 
-func get_column_count() -> int:
-	return _columns.size()
+## Returns all columns, in display order.
+func get_all_columns() -> Array[ColumnConfig]:
+	return _columns.duplicate()
+
+
+func _column_index(col: StringName) -> int:
+	return _column_index_by_id.get(col, -1)
 
 
 ## Replace all rows. Preserves focused_row and selected_rows for keys that still exist.
@@ -324,7 +343,7 @@ func set_data(rows: Array, row_ids: Array[StringName]) -> void:
 
 	if not _rows.has(focused_row):
 		focused_row = &""
-		focused_col = -1
+		focused_col = &""
 	if not _rows.has(_anchor_row):
 		_anchor_row = &""
 
@@ -369,7 +388,7 @@ func remove_row(row: StringName) -> void:
 	selected_rows.erase(row)
 	if focused_row == row:
 		focused_row = &""
-		focused_col = -1
+		focused_col = &""
 	if _anchor_row == row:
 		_anchor_row = &""
 	_total_rows = _order.size()
@@ -377,23 +396,24 @@ func remove_row(row: StringName) -> void:
 	queue_redraw()
 
 
-func ordering_data(column_index: int, ascending: bool = true) -> void:
-	if not get_column(column_index):
+func ordering_data(column: StringName, ascending: bool = true) -> void:
+	var column_cfg := get_column(column)
+	if not column_cfg:
 		return
 	_finish_editing(false)
-	sort_column = column_index
+	sort_column = column
 	sort_ascending = ascending
-	var column := get_column(column_index)
+	var column_idx := _column_index(column)
 	_icon_sort = " ▼ " if ascending else " ▲ "
 
 	_order.sort_custom(
 		func(a: StringName, b: StringName) -> bool:
 			var a_cells: Array = _rows.get(a, [])
 			var b_cells: Array = _rows.get(b, [])
-			var va: Variant = a_cells[column_index] if column_index < a_cells.size() else null
-			var vb: Variant = b_cells[column_index] if column_index < b_cells.size() else null
-			var ka: Variant = _key_for_sort(va, column)
-			var kb: Variant = _key_for_sort(vb, column)
+			var va: Variant = a_cells[column_idx] if column_idx < a_cells.size() else null
+			var vb: Variant = b_cells[column_idx] if column_idx < b_cells.size() else null
+			var ka: Variant = _key_for_sort(va, column_cfg)
+			var kb: Variant = _key_for_sort(vb, column_cfg)
 			if ka == null and kb == null:
 				return false
 			if ka == null:
@@ -414,19 +434,21 @@ func ordering_data(column_index: int, ascending: bool = true) -> void:
 	queue_redraw()
 
 
-func update_cell(row: StringName, col: int, value: Variant) -> void:
-	if not _rows.has(row) or col < 0 or col >= _columns.size():
+func update_cell(row: StringName, col: StringName, value: Variant) -> void:
+	var col_idx := _column_index(col)
+	if not _rows.has(row) or col_idx < 0:
 		return
-	while _rows[row].size() <= col:
+	while _rows[row].size() <= col_idx:
 		_rows[row].append(CELL_INVALID)
-	_rows[row][col] = value
+	_rows[row][col_idx] = value
 	queue_redraw()
 
 
-func get_cell_value(row: StringName, col: int) -> Variant:
-	if not _rows.has(row) or col < 0 or col >= _rows[row].size():
+func get_cell_value(row: StringName, col: StringName) -> Variant:
+	var col_idx := _column_index(col)
+	if not _rows.has(row) or col_idx < 0 or col_idx >= _rows[row].size():
 		return null
-	var raw: Variant = _rows[row][col]
+	var raw: Variant = _rows[row][col_idx]
 	if is_cell_invalid(row, col):
 		return raw
 	if get_column(col) and get_column(col).is_numeric_column() and not _is_numeric_value(raw):
@@ -434,9 +456,9 @@ func get_cell_value(row: StringName, col: int) -> Variant:
 	return raw
 
 
-func set_selected_cell(row: StringName, col: int) -> void:
+func set_selected_cell(row: StringName, col: StringName) -> void:
 	var idx := _order.find(row)
-	if row != &"" and idx >= 0 and col >= 0 and col < _columns.size():
+	if row != &"" and idx >= 0 and col != &"" and get_column(col):
 		focused_row = row
 		focused_col = col
 		selected_rows.clear()
@@ -447,7 +469,7 @@ func set_selected_cell(row: StringName, col: int) -> void:
 		queue_redraw()
 	else:
 		focused_row = &""
-		focused_col = -1
+		focused_col = &""
 		selected_rows.clear()
 		_anchor_row = &""
 		queue_redraw()
@@ -461,17 +483,18 @@ func select_all_rows() -> void:
 	if focused_row == &"":
 		focused_row = _order[0]
 		_anchor_row = _order[0]
-		focused_col = 0 if _columns.size() > 0 else -1
+		focused_col = _columns[0].identifier if not _columns.is_empty() else &""
 	else:
 		_anchor_row = focused_row
 	_ensure_row_visible(focused_row)
 	_ensure_col_visible(focused_col)
 
 
-func is_cell_invalid(row: StringName, col: int) -> bool:
-	if not _rows.has(row) or col >= _rows[row].size():
+func is_cell_invalid(row: StringName, col: StringName) -> bool:
+	var col_idx := _column_index(col)
+	if not _rows.has(row) or col_idx < 0 or col_idx >= _rows[row].size():
 		return false
-	var raw: Variant = _rows[row][col]
+	var raw: Variant = _rows[row][col_idx]
 	return raw is String and raw == CELL_INVALID
 
 
@@ -560,7 +583,7 @@ func _update_scrollbars() -> void:
 	var visible_scrollable_w := visible_width - frozen_w
 	var total_scrollable_w := 0.0
 	for i in range(n_frozen_columns, _columns.size()):
-		total_scrollable_w += get_column(i).current_width
+		total_scrollable_w += _columns[i].current_width
 
 	_h_scroll.visible = total_scrollable_w > visible_scrollable_w
 	_h_scroll.offset_left = frozen_w
@@ -589,7 +612,7 @@ func _is_numeric_value(value: Variant) -> bool:
 	return str_val.is_valid_float() or str_val.is_valid_int()
 
 
-func _start_cell_editing(row: StringName, col: int) -> void:
+func _start_cell_editing(row: StringName, col: StringName) -> void:
 	var column := get_column(col)
 	if is_cell_invalid(row, col):
 		return
@@ -608,7 +631,7 @@ func _start_cell_editing(row: StringName, col: int) -> void:
 		YardLogger.warn("There is no editor for this type of cell.")
 
 
-func _open_text_editor(row: StringName, col: int) -> void:
+func _open_text_editor(row: StringName, col: StringName) -> void:
 	var cell_rect := _get_cell_rect(row, col)
 	if not cell_rect:
 		return
@@ -625,7 +648,7 @@ func _open_text_editor(row: StringName, col: int) -> void:
 	_text_editor_line_edit.select_all()
 
 
-func _open_color_editor(row: StringName, col: int) -> void:
+func _open_color_editor(row: StringName, col: StringName) -> void:
 	var cell_rect := _get_cell_rect(row, col)
 	if not cell_rect:
 		return
@@ -639,7 +662,7 @@ func _open_color_editor(row: StringName, col: int) -> void:
 	_color_editor.grab_focus()
 
 
-func _open_resource_editor(row: StringName, col: int) -> void:
+func _open_resource_editor(row: StringName, col: StringName) -> void:
 	_edited_row = row
 	_edited_col = col
 	var column := get_column(col)
@@ -656,7 +679,7 @@ func _open_resource_editor(row: StringName, col: int) -> void:
 			break
 
 
-func _open_path_editor(row: StringName, col: int) -> void:
+func _open_path_editor(row: StringName, col: StringName) -> void:
 	_edited_row = row
 	_edited_col = col
 	var cell_value: String = get_cell_value(row, col)
@@ -674,7 +697,7 @@ func _open_path_editor(row: StringName, col: int) -> void:
 	_path_editor.popup_centered_ratio(0.55)
 
 
-func _open_enum_editor(row: StringName, col: int) -> void:
+func _open_enum_editor(row: StringName, col: StringName) -> void:
 	_edited_row = row
 	_edited_col = col
 	var current_value: Variant = get_cell_value(row, col)
@@ -705,7 +728,7 @@ func _open_enum_editor(row: StringName, col: int) -> void:
 
 
 func _finish_editing(save_changes: bool = true) -> void:
-	if _edited_row == &"" and _edited_col == -1:
+	if _edited_row == &"" and _edited_col == &"":
 		return
 
 	if save_changes:
@@ -719,7 +742,7 @@ func _finish_editing(save_changes: bool = true) -> void:
 			cell_edited.emit(_edited_row, _edited_col, old_value, new_value)
 
 	_edited_row = &""
-	_edited_col = -1
+	_edited_col = &""
 	_text_editor_line_edit.hide()
 	_color_editor.hide()
 	queue_redraw()
@@ -751,42 +774,44 @@ func _get_editor_value_for_column(column: ColumnConfig) -> Variant:
 	return null
 
 
-func _get_cell_rect(row: StringName, col: int) -> Rect2:
+func _get_cell_rect(row: StringName, col: StringName) -> Rect2:
 	var row_idx := _order.find(row)
-	if row_idx < _visible_rows_range[0] or row_idx >= _visible_rows_range[1] or col >= _columns.size():
+	var col_idx := _column_index(col)
+	if row_idx < _visible_rows_range[0] or row_idx >= _visible_rows_range[1] or col_idx < 0:
 		return Rect2()
-	var cell_x := _get_col_x_pos(col)
+	var cell_x := _get_col_x_pos(col_idx)
 	var vis_w := size.x - (_v_scroll.size.x if _v_scroll.visible else 0.)
-	if cell_x + get_column(col).current_width <= 0 or cell_x >= vis_w:
+	var col_cfg := get_column(col)
+	if cell_x + col_cfg.current_width <= 0 or cell_x >= vis_w:
 		return Rect2()
 	var row_y := header_height + (row_idx - _visible_rows_range[0]) * row_height
-	return Rect2(cell_x, row_y, get_column(col).current_width, row_height)
+	return Rect2(cell_x, row_y, col_cfg.current_width, row_height)
 
 
-func _dispatch_cell_draw(cell_rect: Rect2, row: StringName, col_idx: int) -> void:
-	var col := get_column(col_idx)
-	if is_cell_invalid(row, col_idx):
-		_draw_cell_invalid(cell_rect, row, col_idx)
-	elif col.is_range_column():
-		_draw_cell_progress(cell_rect, row, col_idx)
-	elif col.is_boolean_column():
-		_draw_cell_bool(cell_rect, row, col_idx)
-	elif col.is_color_column():
-		_draw_cell_color(cell_rect, row, col_idx)
-	elif col.is_resource_column():
-		_draw_cell_resource(cell_rect, row, col_idx)
-	elif col.is_path_column():
-		_draw_cell_path(cell_rect, row, col_idx)
-	elif col.is_enum_column():
-		_draw_cell_enum(cell_rect, row, col_idx)
-	elif col.is_collection_column():
-		_draw_cell_collection(cell_rect, row, col_idx)
+func _dispatch_cell_draw(cell_rect: Rect2, row: StringName, col: StringName) -> void:
+	var column := get_column(col)
+	if is_cell_invalid(row, col):
+		_draw_cell_invalid(cell_rect, row, col)
+	elif column.is_range_column():
+		_draw_cell_progress(cell_rect, row, col)
+	elif column.is_boolean_column():
+		_draw_cell_bool(cell_rect, row, col)
+	elif column.is_color_column():
+		_draw_cell_color(cell_rect, row, col)
+	elif column.is_resource_column():
+		_draw_cell_resource(cell_rect, row, col)
+	elif column.is_path_column():
+		_draw_cell_path(cell_rect, row, col)
+	elif column.is_enum_column():
+		_draw_cell_enum(cell_rect, row, col)
+	elif column.is_collection_column():
+		_draw_cell_collection(cell_rect, row, col)
 	else:
-		_draw_cell_text(cell_rect, row, col_idx)
+		_draw_cell_text(cell_rect, row, col)
 
 
 func _draw_header_cell(col_idx: int, cell_x: float, vis_w: float) -> void:
-	var column := get_column(col_idx)
+	var column := _columns[col_idx]
 	draw_line(Vector2(cell_x, 0), Vector2(cell_x, header_height), grid_color)
 	draw_line(
 		Vector2(cell_x, header_height),
@@ -796,7 +821,7 @@ func _draw_header_cell(col_idx: int, cell_x: float, vis_w: float) -> void:
 
 	var header_text := column.header
 	var font_color := default_font_color
-	if col_idx == _filtered_column:
+	if column.identifier == _filtered_column:
 		font_color = header_filter_active_font_color
 		header_text += " (" + str(_order.size()) + ")"
 
@@ -813,7 +838,7 @@ func _draw_header_cell(col_idx: int, cell_x: float, vis_w: float) -> void:
 		font_color,
 	)
 
-	if col_idx == sort_column:
+	if column.identifier == sort_column:
 		var text_size := font.get_string_size(header_text, header_alignment, column.current_width, font_size)
 		var icon_align := (
 			HORIZONTAL_ALIGNMENT_RIGHT
@@ -843,7 +868,7 @@ func _draw_header_cell(col_idx: int, cell_x: float, vis_w: float) -> void:
 func _draw_header_column_range(col_from: int, col_to: int, start_x: float, clip_left: float, vis_w: float) -> void:
 	var hx := start_x
 	for col_idx in range(col_from, col_to):
-		var col := get_column(col_idx)
+		var col := _columns[col_idx]
 		if hx + col.current_width > clip_left and hx < vis_w:
 			_draw_header_cell(col_idx, hx, vis_w)
 		hx += col.current_width
@@ -852,19 +877,19 @@ func _draw_header_column_range(col_from: int, col_to: int, start_x: float, clip_
 func _draw_cells_column_range(row: StringName, row_y: float, col_from: int, col_to: int, start_x: float, clip_left: float, vis_w: float) -> void:
 	var col_x := start_x
 	for col_idx in range(col_from, col_to):
-		var col := get_column(col_idx)
+		var col := _columns[col_idx]
 		if col_x + col.current_width > clip_left and col_x < vis_w:
 			var cell_rect := Rect2(col_x, row_y, col.current_width, row_height)
 			draw_line(Vector2(col_x, row_y), Vector2(col_x, row_y + row_height), grid_color)
-			_dispatch_cell_draw(cell_rect, row, col_idx)
-			if row == focused_row and col_idx == focused_col:
+			_dispatch_cell_draw(cell_rect, row, col.identifier)
+			if row == focused_row and col.identifier == focused_col:
 				draw_rect(cell_rect.grow_individual(-1, -1, -2, -2), selected_cell_back_color, false, 2.0)
 		col_x += col.current_width
 	if col_to == _columns.size() and col_x <= vis_w and col_x > clip_left:
 		draw_line(Vector2(col_x, row_y), Vector2(col_x, row_y + row_height), grid_color)
 
 
-func _draw_cell_progress(rect: Rect2, row: StringName, col: int) -> void:
+func _draw_cell_progress(rect: Rect2, row: StringName, col: StringName) -> void:
 	var cell_value: float = get_cell_value(row, col)
 	var range_cfg := get_column(col).range_config
 	var progress: float = inverse_lerp(range_cfg.get(&"min"), range_cfg.get(&"max"), cell_value)
@@ -889,7 +914,7 @@ func _draw_cell_progress(rect: Rect2, row: StringName, col: int) -> void:
 	draw_rect(bar, progress_border_color, false, 1.0 * EditorThemeUtils.scale)
 
 
-func _draw_cell_bool(rect: Rect2, row: StringName, col: int) -> void:
+func _draw_cell_bool(rect: Rect2, row: StringName, col: StringName) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	if cell_value is not bool:
 		_draw_cell_text(rect, row, col)
@@ -906,7 +931,7 @@ func _draw_cell_bool(rect: Rect2, row: StringName, col: int) -> void:
 	draw_texture(icon, pos)
 
 
-func _draw_cell_color(rect: Rect2, row: StringName, col: int) -> void:
+func _draw_cell_color(rect: Rect2, row: StringName, col: StringName) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	if cell_value is not Color:
 		_draw_cell_text(rect, row, col)
@@ -942,7 +967,7 @@ func _draw_cell_color(rect: Rect2, row: StringName, col: int) -> void:
 	draw_rect(inner, Color(1, 1, 1, border_alpha), false, 1.0)
 
 
-func _draw_cell_resource(rect: Rect2, row: StringName, col: int) -> void:
+func _draw_cell_resource(rect: Rect2, row: StringName, col: StringName) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	if cell_value is not Resource:
 		_draw_cell_text(rect, row, col, tr("<empty>"))
@@ -970,7 +995,7 @@ func _draw_cell_resource(rect: Rect2, row: StringName, col: int) -> void:
 	_draw_cell_text(text_rect, row, col, label)
 
 
-func _draw_cell_path(rect: Rect2, row: StringName, col: int) -> void:
+func _draw_cell_path(rect: Rect2, row: StringName, col: StringName) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	var is_invalid_uid: bool = cell_value == INVALID_UID
 	if not get_column(col).property_hint == PROPERTY_HINT_FILE:
@@ -1013,7 +1038,7 @@ func _draw_filtered_texture_rect(texture: Texture2D, rect: Rect2) -> void:
 		draw_texture_rect(texture, rect, false)
 
 
-func _draw_cell_text(rect: Rect2, row: StringName, col: int, text_override: String = "", color_override: Color = Color.TRANSPARENT) -> void:
+func _draw_cell_text(rect: Rect2, row: StringName, col: StringName, text_override: String = "", color_override: Color = Color.TRANSPARENT) -> void:
 	var cell_value := str(get_cell_value(row, col))
 
 	var column := get_column(col)
@@ -1045,7 +1070,7 @@ func _draw_cell_text(rect: Rect2, row: StringName, col: int, text_override: Stri
 	)
 
 
-func _draw_cell_enum(rect: Rect2, row: StringName, col: int) -> void:
+func _draw_cell_enum(rect: Rect2, row: StringName, col: StringName) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	var column := get_column(col)
 	var value_str := ""
@@ -1074,11 +1099,11 @@ func _draw_cell_enum(rect: Rect2, row: StringName, col: int) -> void:
 	)
 
 
-func _draw_cell_invalid(rect: Rect2, _row: StringName, _col: int) -> void:
+func _draw_cell_invalid(rect: Rect2, _row: StringName, _col: StringName) -> void:
 	draw_rect(rect, invalid_cell_color, true)
 
 
-func _draw_cell_collection(rect: Rect2, row: StringName, col: int) -> void:
+func _draw_cell_collection(rect: Rect2, row: StringName, col: StringName) -> void:
 	var cell_value: Variant = get_cell_value(row, col)
 	if cell_value is not Array and cell_value is not Dictionary:
 		_draw_cell_text(rect, row, col)
@@ -1184,13 +1209,14 @@ func _fit_texture_rect(texture: Texture2D, container: Rect2, anchor_to_left := f
 	return Rect2(container.position + Vector2(offset_x, offset_y), thumb_size)
 
 
-func _start_filtering(col_idx: int) -> void:
-	if _filtered_column == col_idx and _filter_line_edit.visible:
+func _start_filtering(col: StringName) -> void:
+	if _filtered_column == col and _filter_line_edit.visible:
 		return
 
+	var col_idx := _column_index(col)
 	var col_x := _get_col_x_pos(col_idx)
-	var header_rect := Rect2(col_x, 0, get_column(col_idx).current_width, header_height)
-	_filtered_column = col_idx
+	var header_rect := Rect2(col_x, 0, get_column(col).current_width, header_height)
+	_filtered_column = col
 	_filter_line_edit.position = header_rect.position + Vector2(1, 1)
 	_filter_line_edit.size = header_rect.size - Vector2(2, 2)
 	_filter_line_edit.text = ""
@@ -1203,19 +1229,20 @@ func _apply_filter(search_key: String) -> void:
 		return
 
 	_filter_line_edit.visible = false
-	if _filtered_column == -1:
+	if _filtered_column == &"":
 		return
 
 	if search_key.is_empty():
 		_order = _base_order.duplicate()
-		_filtered_column = -1
+		_filtered_column = &""
 	else:
 		_order.clear()
+		var filtered_col_idx := _column_index(_filtered_column)
 		var key_lower := search_key.to_lower()
 		for row in _base_order:
 			var row_data: Array = _rows.get(row, [])
-			if _filtered_column < row_data.size() and row_data[_filtered_column] != null:
-				var cell_value := str(row_data[_filtered_column]).to_lower()
+			if filtered_col_idx < row_data.size() and row_data[filtered_col_idx] != null:
+				var cell_value := str(row_data[filtered_col_idx]).to_lower()
 				if cell_value.contains(key_lower):
 					_order.append(row)
 
@@ -1231,7 +1258,7 @@ func _apply_filter(search_key: String) -> void:
 	if not _order.has(focused_row):
 		focused_row = &""
 
-	sort_column = -1
+	sort_column = &""
 
 	_update_scrollbars()
 	queue_redraw()
@@ -1263,14 +1290,14 @@ func _get_col_at_x(x: float) -> int:
 
 	if x < frozen_w:
 		for col_idx in n_frozen_columns:
-			if x < col_x + get_column(col_idx).current_width:
+			if x < col_x + _columns[col_idx].current_width:
 				return col_idx
-			col_x += get_column(col_idx).current_width
+			col_x += _columns[col_idx].current_width
 		return -1
 
 	col_x = frozen_w - _h_scroll_position
 	for col_idx in range(n_frozen_columns, _columns.size()):
-		var col_end := col_x + get_column(col_idx).current_width
+		var col_end := col_x + _columns[col_idx].current_width
 		if x >= maxf(col_x, frozen_w) and x < col_end:
 			return col_idx
 		col_x = col_end
@@ -1294,7 +1321,7 @@ func _get_text_baseline_y(cell_y: float, cell_height: float = -1.0) -> float:
 func _get_frozen_width() -> float:
 	var w := 0.0
 	for i in mini(n_frozen_columns, _columns.size()):
-		w += get_column(i).current_width
+		w += _columns[i].current_width
 	return w
 
 
@@ -1302,12 +1329,12 @@ func _get_col_x_pos(col_idx: int) -> float:
 	if col_idx < n_frozen_columns:
 		var x := 0.0
 		for i in col_idx:
-			x += get_column(i).current_width
+			x += _columns[i].current_width
 		return x
 	else:
 		var x := _get_frozen_width() - _h_scroll_position
 		for i in range(n_frozen_columns, col_idx):
-			x += get_column(i).current_width
+			x += _columns[i].current_width
 		return x
 
 
@@ -1317,7 +1344,7 @@ func _check_mouse_over_divider(mouse_pos: Vector2) -> void:
 
 	if mouse_pos.y < header_height:
 		for col_idx in _columns.size():
-			var divider_x := _get_col_x_pos(col_idx) + get_column(col_idx).current_width
+			var divider_x := _get_col_x_pos(col_idx) + _columns[col_idx].current_width
 			if col_idx >= n_frozen_columns and divider_x <= _get_frozen_width():
 				continue
 			var divider_rect := Rect2(divider_x - _divider_width / 2.0, 0, _divider_width, header_height)
@@ -1331,7 +1358,7 @@ func _check_mouse_over_divider(mouse_pos: Vector2) -> void:
 
 func _update_tooltip(mouse_pos: Vector2) -> void:
 	var new_row: StringName = &""
-	var new_col := -1
+	var new_col: StringName = &""
 	var new_tooltip := ""
 
 	var col_idx := _get_col_at_x(mouse_pos.x)
@@ -1342,18 +1369,19 @@ func _update_tooltip(mouse_pos: Vector2) -> void:
 			self.tooltip_text = new_tooltip
 		return
 
+	var col := _columns[col_idx].identifier
 	if mouse_pos.y < header_height:
-		new_tooltip = get_column(col_idx).header
+		new_tooltip = get_column(col).header
 		new_row = &"<header>"
-		new_col = col_idx
+		new_col = col
 	else:
 		var row_idx := _get_row_at_y(mouse_pos.y)
 		if row_idx >= 0:
 			new_row = _order[row_idx]
-			new_col = col_idx
-			var column := get_column(col_idx)
+			new_col = col
+			var column := get_column(col)
 			if not column.is_range_column() and not column.is_boolean_column():
-				new_tooltip = str(get_cell_value(new_row, col_idx))
+				new_tooltip = str(get_cell_value(new_row, col))
 
 	if new_row != _tooltip_row or new_col != _tooltip_col:
 		_tooltip_row = new_row
@@ -1363,13 +1391,13 @@ func _update_tooltip(mouse_pos: Vector2) -> void:
 
 func _is_clicking_progress_bar(mouse_pos: Vector2) -> bool:
 	var row_idx := _get_row_at_y(mouse_pos.y)
-	var col := _get_col_at_x(mouse_pos.x)
-	if row_idx < 0 or col == -1:
+	var col_idx := _get_col_at_x(mouse_pos.x)
+	if row_idx < 0 or col_idx < 0:
 		return false
-	return get_column(col).is_range_column()
+	return _columns[col_idx].is_range_column()
 
 
-func _toggle_checkbox(row: StringName, col: int) -> void:
+func _toggle_checkbox(row: StringName, col: StringName) -> void:
 	var old_val := bool(get_cell_value(row, col))
 	var new_val := !old_val
 	update_cell(row, col, new_val)
@@ -1393,16 +1421,17 @@ func _ensure_row_visible(row: StringName) -> void:
 	_v_scroll.value = clamp(_v_scroll.value, 0, _v_scroll.max_value)
 
 
-func _ensure_col_visible(col_idx: int) -> void:
-	if _columns.is_empty() or col_idx < 0 or col_idx >= _columns.size() or not _h_scroll.visible:
+func _ensure_col_visible(col: StringName) -> void:
+	var col_idx := _column_index(col)
+	if _columns.is_empty() or col_idx < 0 or not _h_scroll.visible:
 		return
 	if col_idx < n_frozen_columns:
 		return
 
 	var col_scroll_pos := 0.0
 	for i in range(n_frozen_columns, col_idx):
-		col_scroll_pos += get_column(i).current_width
-	var col_scroll_end := col_scroll_pos + get_column(col_idx).current_width
+		col_scroll_pos += _columns[i].current_width
+	var col_scroll_end := col_scroll_pos + _columns[col_idx].current_width
 	var visible_scrollable_w := _h_scroll.page
 
 	if col_scroll_pos < _h_scroll.value:
@@ -1410,7 +1439,7 @@ func _ensure_col_visible(col_idx: int) -> void:
 	elif col_scroll_end > _h_scroll.value + visible_scrollable_w:
 		_h_scroll.value = (
 			col_scroll_end - visible_scrollable_w
-			if get_column(col_idx).current_width <= visible_scrollable_w
+			if _columns[col_idx].current_width <= visible_scrollable_w
 			else col_scroll_pos
 		)
 	_h_scroll.value = clamp(_h_scroll.value, 0.0, _h_scroll.max_value)
@@ -1425,9 +1454,9 @@ func _handle_pan_gesture(event: InputEventPanGesture) -> void:
 func _handle_mouse_motion(event: InputEventMouseMotion) -> void:
 	var m_pos := event.position
 
-	if _dragging_progress and _progress_drag_row != &"" and _progress_drag_col >= 0:
+	if _dragging_progress and _progress_drag_row != &"" and _progress_drag_col != &"":
 		_handle_progress_drag(m_pos)
-	elif _resizing_column in range(_columns.size()):
+	elif _resizing_column != &"":
 		var delta_x: float = m_pos.x - _resizing_start_pos
 		var new_width: float = max(
 			_resizing_start_width + delta_x,
@@ -1492,13 +1521,14 @@ func _handle_left_press(event: InputEventMouseButton) -> void:
 		_handle_cell_click(m_pos, event)
 		if _is_clicking_progress_bar(m_pos):
 			var row_idx := _get_row_at_y(m_pos.y)
+			var col_idx := _get_col_at_x(m_pos.x)
 			_progress_drag_row = _order[row_idx]
-			_progress_drag_col = _get_col_at_x(m_pos.x)
+			_progress_drag_col = _columns[col_idx].identifier
 			_dragging_start_value = get_cell_value(_progress_drag_row, _progress_drag_col)
 			_dragging_progress = true
 
 	if _mouse_over_divider >= 0:
-		_resizing_column = _mouse_over_divider
+		_resizing_column = _columns[_mouse_over_divider].identifier
 		_resizing_start_pos = int(m_pos.x)
 		_resizing_start_width = int(get_column(_resizing_column).current_width)
 
@@ -1508,18 +1538,18 @@ func _handle_left_release() -> void:
 		var new_val: Variant = get_cell_value(_progress_drag_row, _progress_drag_col)
 		update_cell(_progress_drag_row, _progress_drag_col, new_val)
 		cell_edited.emit(_progress_drag_row, _progress_drag_col, _dragging_start_value, new_val)
-	_resizing_column = -1
+	_resizing_column = &""
 	_dragging_progress = false
 	_progress_drag_row = &""
-	_progress_drag_col = -1
+	_progress_drag_col = &""
 
 
 func _handle_progress_drag(mouse_pos: Vector2) -> void:
-	if _progress_drag_row == &"" or _progress_drag_col < 0 or _progress_drag_col >= _columns.size():
+	if _progress_drag_row == &"" or _progress_drag_col == &"":
 		return
 
 	var margin := 4.0
-	var bar_x := _get_col_x_pos(_progress_drag_col) + margin
+	var bar_x := _get_col_x_pos(_column_index(_progress_drag_col)) + margin
 	var bar_w := get_column(_progress_drag_col).current_width - margin * 2.0
 	if bar_w <= 0:
 		return
@@ -1535,21 +1565,23 @@ func _handle_progress_drag(mouse_pos: Vector2) -> void:
 	if not range_cfg.has(&"or_less"):
 		new_progress = max(new_progress, range_cfg.get(&"min"))
 
-	if _rows.has(_progress_drag_row) and _progress_drag_col < _rows[_progress_drag_row].size():
-		_rows[_progress_drag_row][_progress_drag_col] = new_progress
+	var col_idx := _column_index(_progress_drag_col)
+	if _rows.has(_progress_drag_row) and col_idx < _rows[_progress_drag_row].size():
+		_rows[_progress_drag_row][col_idx] = new_progress
 		progress_changed.emit(_progress_drag_row, _progress_drag_col, new_progress)
 		queue_redraw()
 
 
 func _handle_checkbox_click(mouse_pos: Vector2) -> bool:
 	var row_idx := _get_row_at_y(mouse_pos.y)
-	var col := _get_col_at_x(mouse_pos.x)
-	if row_idx < 0 or col == -1:
+	var col_idx := _get_col_at_x(mouse_pos.x)
+	if row_idx < 0 or col_idx == -1:
 		return false
-	if not get_column(col).is_boolean_column():
+	if not _columns[col_idx].is_boolean_column():
 		return false
 
 	var row := _order[row_idx]
+	var col := _columns[col_idx].identifier
 	var rect := _get_cell_rect(row, col)
 	var icon: Texture2D = get_theme_icon(&"checked", &"CheckBox")
 	var icon_rect := Rect2(rect.get_center() - icon.get_size() / 2, icon.get_size())
@@ -1560,17 +1592,18 @@ func _handle_checkbox_click(mouse_pos: Vector2) -> bool:
 
 
 func _handle_cell_click(mouse_pos: Vector2, event: InputEventMouseButton) -> void:
-	if _edited_col >= 0:
+	if _edited_col != &"":
 		var column := get_column(_edited_col)
 		var save := not (column.is_resource_column() or column.is_path_column() or column.is_enum_column())
 		_finish_editing(save)
 
 	var clicked_idx := _get_row_at_y(mouse_pos.y)
-	var clicked_col := _get_col_at_x(mouse_pos.x)
-	if clicked_idx < 0 or clicked_col == -1:
+	var clicked_col_idx := _get_col_at_x(mouse_pos.x)
+	if clicked_idx < 0 or clicked_col_idx == -1:
 		return
 
 	var clicked_row := _order[clicked_idx]
+	var clicked_col := _columns[clicked_col_idx].identifier
 	focused_row = clicked_row
 	focused_col = clicked_col
 
@@ -1601,8 +1634,9 @@ func _handle_cell_click(mouse_pos: Vector2, event: InputEventMouseButton) -> voi
 
 func _handle_right_click(mouse_pos: Vector2) -> void:
 	var clicked_idx := _get_row_at_y(mouse_pos.y)
-	var clicked_col := _get_col_at_x(mouse_pos.x)
+	var clicked_col_idx := _get_col_at_x(mouse_pos.x)
 	var clicked_row := _order[clicked_idx] if clicked_idx >= 0 else &""
+	var clicked_col := _columns[clicked_col_idx].identifier if clicked_col_idx >= 0 else &""
 
 	if selected_rows.size() <= 1:
 		set_selected_cell(clicked_row, clicked_col)
@@ -1617,8 +1651,9 @@ func _handle_double_click(mouse_pos: Vector2) -> void:
 	var row_idx := _get_row_at_y(mouse_pos.y)
 	if row_idx >= 0:
 		var row := _order[row_idx]
-		var col := _get_col_at_x(mouse_pos.x)
-		if col != -1:
+		var col_idx := _get_col_at_x(mouse_pos.x)
+		if col_idx != -1:
+			var col := _columns[col_idx].identifier
 			if not (selected_rows.size() == 1 and selected_rows[0] == row and focused_row == row and focused_col == col):
 				set_selected_cell(row, col)
 			_start_cell_editing(row, col)
@@ -1629,12 +1664,13 @@ func _handle_header_click(mouse_pos: Vector2) -> void:
 		var col_x := _get_col_x_pos(col_idx)
 		if (
 			mouse_pos.x >= col_x + _divider_width / 2.0
-			and mouse_pos.x < col_x + get_column(col_idx).current_width - _divider_width / 2.0
+			and mouse_pos.x < col_x + _columns[col_idx].current_width - _divider_width / 2.0
 		):
+			var col := _columns[col_idx].identifier
 			_finish_editing(false)
-			sort_ascending = not sort_ascending if sort_column == col_idx else true
-			ordering_data(col_idx, sort_ascending)
-			header_clicked.emit(col_idx)
+			sort_ascending = not sort_ascending if sort_column == col else true
+			ordering_data(col, sort_ascending)
+			header_clicked.emit(col)
 			break
 
 
@@ -1642,8 +1678,9 @@ func _handle_header_double_click(mouse_pos: Vector2) -> void:
 	_finish_editing(false)
 	var col_idx := _get_col_at_x(mouse_pos.x)
 	if col_idx != -1:
-		_ensure_col_visible(col_idx)
-		_start_filtering(col_idx)
+		var col := _columns[col_idx].identifier
+		_ensure_col_visible(col)
+		_start_filtering(col)
 
 
 func _handle_key_input(event: InputEventKey) -> void:
@@ -1656,11 +1693,12 @@ func _handle_key_input(event: InputEventKey) -> void:
 	var keycode := event.keycode
 	var is_shift := event.is_shift_pressed()
 	var is_ctrl_cmd := event.is_ctrl_pressed() or event.is_meta_pressed()
-	var is_cell_focused := focused_row != &"" and focused_col != -1
+	var is_cell_focused := focused_row != &"" and focused_col != &""
 
 	var focused_idx := _order.find(focused_row) if focused_row != &"" else -1
+	var focused_col_idx := _column_index(focused_col) if focused_col != &"" else -1
 	var new_idx := focused_idx
-	var new_col := focused_col
+	var new_col_idx := focused_col_idx
 
 	match keycode:
 		KEY_ENTER, KEY_KP_ENTER:
@@ -1681,19 +1719,19 @@ func _handle_key_input(event: InputEventKey) -> void:
 		KEY_ESCAPE:
 			if selected_rows.is_empty() and focused_row == &"":
 				return
-			set_selected_cell(&"", -1)
+			set_selected_cell(&"", &"")
 			_finalize_key_operation()
 			return
 		KEY_HOME:
 			if _total_rows == 0:
 				return
 			new_idx = 0
-			new_col = 0 if not _columns.is_empty() else -1
+			new_col_idx = 0 if not _columns.is_empty() else -1
 		KEY_END:
 			if _total_rows == 0:
 				return
 			new_idx = _total_rows - 1
-			new_col = _columns.size() - 1 if not _columns.is_empty() else -1
+			new_col_idx = _columns.size() - 1 if not _columns.is_empty() else -1
 		KEY_UP:
 			if not is_cell_focused:
 				return
@@ -1705,11 +1743,11 @@ func _handle_key_input(event: InputEventKey) -> void:
 		KEY_LEFT:
 			if not is_cell_focused:
 				return
-			new_col = maxi(0, focused_col - 1)
+			new_col_idx = maxi(0, focused_col_idx - 1)
 		KEY_RIGHT:
 			if not is_cell_focused:
 				return
-			new_col = mini(_columns.size() - 1, focused_col + 1)
+			new_col_idx = mini(_columns.size() - 1, focused_col_idx + 1)
 		KEY_PAGEUP:
 			if not is_cell_focused:
 				return
@@ -1733,6 +1771,7 @@ func _handle_key_input(event: InputEventKey) -> void:
 			return
 
 	var new_row := _order[new_idx] if new_idx >= 0 and new_idx < _order.size() else &""
+	var new_col := _columns[new_col_idx].identifier if new_col_idx >= 0 and new_col_idx < _columns.size() else &""
 	var old_row := focused_row
 	var old_col := focused_col
 	focused_row = new_row
@@ -1903,7 +1942,7 @@ func _on_resource_cell_thumb_ready(resource_path: String, preview: Texture2D, th
 #endregion
 
 class ColumnConfig:
-	var identifier: String
+	var identifier: StringName
 	var header: String
 	var type: Variant.Type
 	var property_hint: PropertyHint
@@ -1943,7 +1982,7 @@ class ColumnConfig:
 	var _enum_keys_map_ready := false
 
 
-	func _init(p_identifier: String, p_header: String, p_type: Variant.Type, p_alignment: HorizontalAlignment = HORIZONTAL_ALIGNMENT_LEFT) -> void:
+	func _init(p_identifier: StringName, p_header: String, p_type: Variant.Type, p_alignment: HorizontalAlignment = HORIZONTAL_ALIGNMENT_LEFT) -> void:
 		identifier = p_identifier
 		header = p_header
 		type = p_type

--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -45,9 +45,8 @@ const ACCELERATORS_MAC: Dictionary = {
 const INVALID_UID := "uid://<invalid>"
 const UID_COLUMN_CONFIG := ["uid", "UID", TYPE_STRING]
 const STRINGID_COLUMN_CONFIG := ["string_id", "String ID", TYPE_STRING]
-const NON_PROP_COLUMNS_COUNT := 2
-const STRINGID_COLUMN := 0
-const UID_COLUMN := 1
+const STRINGID_COLUMN: StringName = &"string_id"
+const UID_COLUMN: StringName = &"uid"
 
 var current_cache_data: RegistryCacheData
 var properties_column_info: Array[Dictionary]
@@ -255,9 +254,8 @@ func update_view() -> void:
 
 	dynamic_table.set_columns(_build_columns())
 
-	for idx in dynamic_table.get_column_count():
-		var column := dynamic_table.get_column(idx)
-		match idx:
+	for column: DynamicTable.ColumnConfig in dynamic_table.get_all_columns():
+		match column.identifier:
 			UID_COLUMN:
 				column.current_width = current_cache_data.uid_column_width
 			STRINGID_COLUMN:
@@ -270,7 +268,7 @@ func update_view() -> void:
 	# set_data preserves focused_row and selected_rows for keys that still exist
 	dynamic_table.set_data(rows, row_ids)
 
-	if saved_sort_col >= 0:
+	if saved_sort_col != &"":
 		dynamic_table.ordering_data(saved_sort_col, saved_sort_asc)
 
 	if table_had_focus:
@@ -354,7 +352,7 @@ func get_res_row_data(res: Resource) -> Array[Variant]:
 func toggle_edit_menu_items(edit_menu: PopupMenu) -> void:
 	var row := dynamic_table.focused_row
 	var col := dynamic_table.focused_col
-	var has_selected_cell := row != &"" and col != -1
+	var has_selected_cell := row != &"" and col != &""
 	var has_selected_row := row != &""
 	var cell_value: Variant = dynamic_table.get_cell_value(row, col) if has_selected_cell else null
 	var cant_be_cut := col in [UID_COLUMN, STRINGID_COLUMN]
@@ -605,7 +603,7 @@ func _delete_selected_entries() -> void:
 				"Failed to remove %s from %s." % [uid, current_registry.resource_path.get_file()],
 			)
 
-	dynamic_table.set_selected_cell(&"", -1)
+	dynamic_table.set_selected_cell(&"", &"")
 	update_view()
 
 
@@ -654,11 +652,8 @@ func _on_drag_end() -> void:
 	focus_panel.hide()
 
 
-func _on_cell_selected(string_id: StringName, col: int) -> void:
-	# WARNING: uncommenting it increases the chance of a crash occuring by a lot. Inexplicable,
-	# but supposedly related to switching selected cell with arrow keys. Only report: 'Abort trap: 6'
-	#print("Cell selected on row ", row, ", column ", column, " Cell value: ", dynamic_table.get_cell_value(row, column)) #, " Row value: ", dynamic_table.get_row_value(row))
-	if string_id != &"" and col != -1:
+func _on_cell_selected(string_id: StringName, col: StringName) -> void:
+	if string_id != &"" and col != &"":
 		var cell_value: Variant = dynamic_table.get_cell_value(string_id, col)
 		if cell_value is Resource:
 			_subresource_to_inspect = cell_value
@@ -670,7 +665,7 @@ func _on_cell_selected(string_id: StringName, col: int) -> void:
 				_uid_resource_to_inspect = uid
 
 
-func _on_cell_right_selected(string_id: StringName, _col: int, _mouse_pos: Vector2) -> void:
+func _on_cell_right_selected(string_id: StringName, _col: StringName, _mouse_pos: Vector2) -> void:
 	if string_id != &"":
 		edit_context_menu.popup(Rect2(DisplayServer.mouse_get_position(), Vector2.ZERO))
 
@@ -679,13 +674,12 @@ func _on_multiple_rows_selected(_ids: Array[StringName]) -> void:
 	pass
 
 
-func _on_cell_edited(string_id: StringName, column: int, old_value: Variant, new_value: Variant) -> void:
+func _on_cell_edited(string_id: StringName, column: StringName, old_value: Variant, new_value: Variant) -> void:
 	if column not in [UID_COLUMN, STRINGID_COLUMN]:
-		var col_config: DynamicTable.ColumnConfig = dynamic_table.get_column(column)
-		var prop_name: StringName = col_config.identifier
 		var uid := current_registry.get_uid(string_id)
+		var property := column
 		if RegistryIO.is_uid_valid(uid):
-			_edit_entry_property(uid, prop_name, old_value, new_value)
+			_edit_entry_property(uid, property, old_value, new_value)
 	elif column == STRINGID_COLUMN and new_value:
 		RegistryIO.rename_entry(current_registry, string_id, new_value)
 	elif column == UID_COLUMN and new_value:
@@ -694,16 +688,14 @@ func _on_cell_edited(string_id: StringName, column: int, old_value: Variant, new
 	update_view()
 
 
-func _on_column_resized(column: int, new_width: float) -> void:
+func _on_column_resized(column: StringName, new_width: float) -> void:
 	match column:
 		UID_COLUMN:
 			current_cache_data.uid_column_width = new_width
 		STRINGID_COLUMN:
 			current_cache_data.string_id_column_width = new_width
 		_:
-			var col_config: DynamicTable.ColumnConfig = dynamic_table.get_column(column)
-			var prop_name: StringName = col_config.identifier
-			current_cache_data.property_columns_widths[prop_name] = new_width
+			current_cache_data.property_columns_widths[column] = new_width
 
 	current_cache_data.save()
 

--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -51,7 +51,6 @@ const UID_COLUMN := 1
 
 var current_cache_data: RegistryCacheData
 var properties_column_info: Array[Dictionary]
-var entries_data: Array[Array] # inner arrays are rows, their content is columns
 var clipboard: Variant
 
 var current_registry: Registry:
@@ -61,8 +60,9 @@ var current_registry: Registry:
 		current_cache_data = RegistryCacheData.load_or_default(new) if new else null
 		if current_cache_data:
 			_setup_add_entry()
-			if is_another:
-				dynamic_table.ordering_data(STRINGID_COLUMN, true)
+		if is_another:
+			dynamic_table.sort_column = STRINGID_COLUMN
+			dynamic_table.sort_ascending = true
 		update_view()
 
 var toggle_button_forward := false:
@@ -74,7 +74,7 @@ var id_columns_frozen := true:
 	set(frozen):
 		id_columns_frozen = frozen
 		dynamic_table.n_frozen_columns = 2 if frozen else 0
-		dynamic_table._update_scrollbars() # private but whatever
+		dynamic_table.refresh_layout()
 
 var _texture_rect_parent: Button
 var _res_picker: EditorResourcePicker
@@ -104,7 +104,6 @@ func _ready() -> void:
 	dynamic_table.cell_selected.connect(_on_cell_selected)
 	dynamic_table.cell_right_selected.connect(_on_cell_right_selected)
 	dynamic_table.cell_edited.connect(_on_cell_edited)
-	dynamic_table.header_clicked.connect(_on_header_clicked)
 	dynamic_table.column_resized.connect(_on_column_resized)
 	dynamic_table.multiple_rows_selected.connect(_on_multiple_rows_selected)
 	entry_name_line_edit.text_submitted.connect(_on_new_entry_text_submitted)
@@ -114,7 +113,6 @@ func _ready() -> void:
 		if edit_context_menu.get_item_index(action) != -1:
 			edit_context_menu.set_item_accelerator(edit_context_menu.get_item_index(action), accelerators.get(action))
 
-	# Resource Picker Theming
 	resource_picker_container.add_theme_stylebox_override(
 		&"panel",
 		get_theme_stylebox("normal", "LineEdit").duplicate(),
@@ -124,9 +122,7 @@ func _ready() -> void:
 	resource_picker_container.get_theme_stylebox(&"panel").content_margin_left = 0
 	resource_picker_container.get_theme_stylebox(&"panel").content_margin_right = 0
 
-	drag_and_drop_info_panel.get_theme_stylebox(&"panel").bg_color = EditorThemeUtils.get_base_color(
-		0.6,
-	)
+	drag_and_drop_info_panel.get_theme_stylebox(&"panel").bg_color = EditorThemeUtils.get_base_color(0.6)
 	drag_and_drop_info_panel.get_theme_stylebox(&"panel").bg_color.a = 0.8
 	focus_panel.add_theme_stylebox_override(&"panel", get_theme_stylebox("Focus", "EditorStyles"))
 
@@ -230,11 +226,11 @@ func update_view() -> void:
 	if not current_registry:
 		add_entry_container.visible = false
 		dynamic_table.set_columns([])
-		var empty_data: Array[Array] = [[]]
-		dynamic_table.set_data(empty_data)
+		dynamic_table.set_data([], [])
 		return
 
-	var table_state := [dynamic_table.focused_row, dynamic_table.focused_col, dynamic_table.selected_rows, dynamic_table._last_column_sorted, dynamic_table._ascending]
+	var saved_sort_col := dynamic_table.sort_column
+	var saved_sort_asc := dynamic_table.sort_ascending
 	var focus_owner := get_viewport().gui_get_focus_owner() if get_viewport() else null
 	var table_had_focus := focus_owner and (dynamic_table == focus_owner or dynamic_table.is_ancestor_of(focus_owner))
 
@@ -242,19 +238,24 @@ func update_view() -> void:
 
 	var resources: Dictionary[StringName, Resource] = current_registry.load_all_blocking()
 	set_columns_data(resources.values())
-	entries_data.clear()
+
+	var rows: Array[Array] = []
+	var row_ids: Array[StringName] = []
 	for uid in current_registry.get_all_uids():
-		var entry_data := [current_registry.get_string_id(uid), uid]
+		var string_id: StringName = current_registry.get_string_id(uid)
+		var entry_data: Array[Variant] = [string_id]
 		if RegistryIO.is_uid_valid(uid):
+			entry_data.append(uid)
 			entry_data.append_array(get_res_row_data(current_registry.load_entry(uid)))
 		else:
-			entry_data[UID_COLUMN] = INVALID_UID
+			entry_data.append(INVALID_UID)
 			entry_data.append_array(get_res_row_data(null))
-		entries_data.append(entry_data)
+		rows.append(entry_data)
+		row_ids.append(string_id)
 
 	dynamic_table.set_columns(_build_columns())
 
-	for idx in dynamic_table._columns.size():
+	for idx in dynamic_table.get_column_count():
 		var column := dynamic_table.get_column(idx)
 		match idx:
 			UID_COLUMN:
@@ -266,50 +267,47 @@ func update_view() -> void:
 				if current_cache_data.property_columns_widths.has(prop_name):
 					column.current_width = current_cache_data.property_columns_widths[prop_name]
 
-	dynamic_table.set_data(entries_data)
+	# set_data preserves focused_row and selected_rows for keys that still exist
+	dynamic_table.set_data(rows, row_ids)
 
-	dynamic_table.ordering_data(table_state[3], table_state[4])
+	if saved_sort_col >= 0:
+		dynamic_table.ordering_data(saved_sort_col, saved_sort_asc)
+
 	if table_had_focus:
 		dynamic_table.grab_focus()
-		dynamic_table.set_selected_cell(table_state[0], table_state[1])
-		dynamic_table.selected_rows = table_state[2]
 
 
 func do_edit_menu_action(action_id: int) -> void:
 	if not current_registry:
 		return
+	var focused_row := dynamic_table.focused_row
+	var focused_col := dynamic_table.focused_col
 	match action_id:
 		EditMenuAction.DELETE_ENTRIES:
 			_ask_confirm_delete_entries()
 		EditMenuAction.COPY_STRING_ID:
-			DisplayServer.clipboard_set(get_row_resource_string_id(dynamic_table.focused_row))
+			DisplayServer.clipboard_set(focused_row)
 		EditMenuAction.COPY_UID:
-			DisplayServer.clipboard_set(get_row_resource_uid(dynamic_table.focused_row))
+			DisplayServer.clipboard_set(current_registry.get_uid(focused_row))
 		EditMenuAction.SHOW_IN_FILESYSTEM:
-			var uid := get_row_resource_uid(dynamic_table.focused_row)
+			var uid := current_registry.get_uid(focused_row)
 			var path := ResourceUID.uid_to_path(uid)
 			EditorInterface.get_file_system_dock().navigate_to_path(path)
 		EditMenuAction.DUPLICATE_ENTRIES:
 			_duplicate_selected_entries()
 		EditMenuAction.CUT_CELL_VALUE:
-			var row := dynamic_table.focused_row
-			var col := dynamic_table.focused_col
-			var value: Variant = dynamic_table.get_cell_value(row, col)
-			if not dynamic_table.is_cell_invalid(row, col):
+			var value: Variant = dynamic_table.get_cell_value(focused_row, focused_col)
+			if not dynamic_table.is_cell_invalid(focused_row, focused_col):
 				clipboard = value
-				_on_cell_edited(row, col, value, null)
+				_on_cell_edited(focused_row, focused_col, value, null)
 		EditMenuAction.COPY_CELL_VALUE:
-			var row := dynamic_table.focused_row
-			var col := dynamic_table.focused_col
-			var value: Variant = dynamic_table.get_cell_value(row, col)
-			if not dynamic_table.is_cell_invalid(row, col):
+			var value: Variant = dynamic_table.get_cell_value(focused_row, focused_col)
+			if not dynamic_table.is_cell_invalid(focused_row, focused_col):
 				clipboard = value
 		EditMenuAction.PASTE_TO_CELL:
-			var row := dynamic_table.focused_row
-			var col := dynamic_table.focused_col
-			var value: Variant = dynamic_table.get_cell_value(row, col)
-			if not dynamic_table.is_cell_invalid(row, col):
-				_on_cell_edited(row, col, value, clipboard)
+			var value: Variant = dynamic_table.get_cell_value(focused_row, focused_col)
+			if not dynamic_table.is_cell_invalid(focused_row, focused_col):
+				_on_cell_edited(focused_row, focused_col, value, clipboard)
 		EditMenuAction.SELECT_ALL:
 			_select_all()
 		EditMenuAction.INVERT_SELECTION:
@@ -353,24 +351,11 @@ func get_res_row_data(res: Resource) -> Array[Variant]:
 	return row
 
 
-func get_row_resource_uid(row: int) -> StringName:
-	var string_id: Variant = dynamic_table.get_cell_value(row, STRINGID_COLUMN)
-	if string_id and string_id is StringName:
-		return current_registry.get_uid(string_id)
-	else:
-		return &""
-
-
-func get_row_resource_string_id(row: int) -> StringName:
-	var string_id: StringName = dynamic_table.get_cell_value(row, STRINGID_COLUMN)
-	return string_id
-
-
 func toggle_edit_menu_items(edit_menu: PopupMenu) -> void:
 	var row := dynamic_table.focused_row
 	var col := dynamic_table.focused_col
-	var has_selected_cell := -1 not in [row, col]
-	var has_selected_row: = row != -1
+	var has_selected_cell := row != &"" and col != -1
+	var has_selected_row := row != &""
 	var cell_value: Variant = dynamic_table.get_cell_value(row, col) if has_selected_cell else null
 	var cant_be_cut := col in [UID_COLUMN, STRINGID_COLUMN]
 	var is_cell_invalid: bool = cell_value is String and cell_value == dynamic_table.CELL_INVALID
@@ -406,12 +391,12 @@ func _build_columns() -> Array[DynamicTable.ColumnConfig]:
 	var string_id_column: DynamicTable.ColumnConfig = DynamicTable.ColumnConfig.new.callv(STRINGID_COLUMN_CONFIG)
 	string_id_column.custom_font_color = get_theme_color(&"accent_color", &"Editor")
 	string_id_column.h_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-	columns.append(string_id_column) #0
+	columns.append(string_id_column)
 
 	var uid_column: DynamicTable.ColumnConfig = DynamicTable.ColumnConfig.new.callv(UID_COLUMN_CONFIG)
 	uid_column.custom_font_color = get_theme_color(&"disabled_font_color", &"Editor")
 	uid_column.property_hint = PROPERTY_HINT_FILE
-	columns.append(uid_column) #1
+	columns.append(uid_column)
 
 	for prop in properties_column_info:
 		if not _can_display_property(prop) or is_property_disabled(prop):
@@ -478,13 +463,11 @@ func _can_display_property(property_info: Dictionary) -> bool:
 	)
 
 
-func _edit_entry_property(entry: StringName, property: StringName, old_value: Variant, new_value: Variant) -> void:
-	var uid := current_registry.get_uid(entry)
-	var string_id := current_registry.get_string_id(uid)
-	if not uid or not RegistryIO.is_uid_valid(uid):
+func _edit_entry_property(uid: StringName, property: StringName, old_value: Variant, new_value: Variant) -> void:
+	if not RegistryIO.is_uid_valid(uid):
 		return
 
-	var res := load(entry)
+	var res := load(uid)
 	if not property in res:
 		YardLogger.error("Property %s not in resource" % property)
 		return
@@ -522,6 +505,7 @@ func _edit_entry_property(entry: StringName, property: StringName, old_value: Va
 		)
 		return
 
+	var string_id := current_registry.get_string_id(uid)
 	var undo_redo := EditorInterface.get_editor_undo_redo()
 	undo_redo.create_action("Set %s—>%s" % [string_id, property])
 	undo_redo.add_do_property(res, property, new_value)
@@ -532,7 +516,7 @@ func _edit_entry_property(entry: StringName, property: StringName, old_value: Va
 
 func _ask_confirm_delete_entries() -> void:
 	var dialogtext := "Are you sure you want to delete %s?"
-	if not dynamic_table.selected_rows.is_empty():
+	if dynamic_table.selected_rows.size() > 1:
 		delete_entries_confirmation_dialog.dialog_text = dialogtext % ["these " + str(dynamic_table.selected_rows.size()) + " entries"]
 	else:
 		delete_entries_confirmation_dialog.dialog_text = dialogtext % "this entry"
@@ -544,10 +528,9 @@ func _setup_add_entry() -> void:
 		_res_picker.queue_free()
 	_res_picker = EditorResourcePicker.new()
 	_res_picker.custom_minimum_size = Vector2(240, 0)
-
 	_res_picker.base_type = "Resource"
-	var settings := RegistryIO.get_registry_settings(current_registry)
 
+	var settings := RegistryIO.get_registry_settings(current_registry)
 	if settings.has_any_class_restrictions():
 		var all_class_restrictions_usable_strings: PackedStringArray
 		for restriction in settings.get_all_class_restrictions():
@@ -595,7 +578,7 @@ func _add_entry_from_picker(res: Resource, string_id: StringName) -> void:
 		ERR_ALREADY_EXISTS:
 			YardLogger.error("An entry with the same UID already exists in the registry.")
 		ERR_CANT_ACQUIRE_RESOURCE:
-			YardLogger.error("This resource is not saved as a file. Click [b]⌄[/b] then [b]Save[/b] on the resource picker to save it first.")
+			YardLogger.error("This resource is not saved as a file. Click [b]v[/b] then [b]Save[/b] on the resource picker to save it first.")
 		ERR_INVALID_PARAMETER:
 			YardLogger.error("The String ID is invalid. It must not start with 'uid://'.")
 		ERR_DATABASE_CANT_WRITE:
@@ -615,20 +598,20 @@ func _toggle_edit_context_menu_items() -> void:
 
 
 func _delete_selected_entries() -> void:
-	for row_idx: int in dynamic_table.selected_rows:
-		var uid := get_row_resource_uid(row_idx)
+	for string_id: StringName in dynamic_table.selected_rows:
+		var uid := current_registry.get_uid(string_id)
 		if RegistryIO.erase_entry(current_registry, uid) != OK:
 			YardLogger.error(
 				"Failed to remove %s from %s." % [uid, current_registry.resource_path.get_file()],
 			)
 
-	dynamic_table.set_selected_cell(-1, -1) # cancel current selection
+	dynamic_table.set_selected_cell(&"", -1)
 	update_view()
 
 
 func _duplicate_selected_entries() -> void:
-	for row_idx: int in dynamic_table.selected_rows:
-		var uid := get_row_resource_uid(row_idx)
+	for string_id: StringName in dynamic_table.selected_rows:
+		var uid := current_registry.get_uid(string_id)
 		if RegistryIO.duplicate_entry(current_registry, uid) != OK:
 			YardLogger.error(
 				"Failed to duplicate %s in %s." % [uid, current_registry.resource_path.get_file()],
@@ -643,8 +626,8 @@ func _select_all() -> void:
 
 func _invert_selection() -> void:
 	var selection := dynamic_table.selected_rows
-	var inverted := []
-	for row in dynamic_table._total_rows:
+	var inverted: Array[StringName] = []
+	for row: StringName in dynamic_table.get_displayed_rows():
 		if row not in selection:
 			inverted.append(row)
 	dynamic_table.selected_rows = inverted
@@ -671,50 +654,44 @@ func _on_drag_end() -> void:
 	focus_panel.hide()
 
 
-func _on_cell_selected(row: int, column: int) -> void:
+func _on_cell_selected(string_id: StringName, col: int) -> void:
 	# WARNING: uncommenting it increases the chance of a crash occuring by a lot. Inexplicable,
 	# but supposedly related to switching selected cell with arrow keys. Only report: 'Abort trap: 6'
 	#print("Cell selected on row ", row, ", column ", column, " Cell value: ", dynamic_table.get_cell_value(row, column)) #, " Row value: ", dynamic_table.get_row_value(row))
-	if row != -1 and column != -1:
-		var cell_value: Variant = dynamic_table.get_cell_value(row, column)
+	if string_id != &"" and col != -1:
+		var cell_value: Variant = dynamic_table.get_cell_value(string_id, col)
 		if cell_value is Resource:
 			_subresource_to_inspect = cell_value
 			_uid_resource_to_inspect = ""
 		else:
 			_subresource_to_inspect = null
-			var uid: StringName = get_row_resource_uid(row)
+			var uid: StringName = current_registry.get_uid(string_id)
 			if RegistryIO.is_uid_valid(uid):
 				_uid_resource_to_inspect = uid
 
 
-func _on_cell_right_selected(row: int, _column: int, _mouse_pos: Vector2) -> void:
-	if (row >= 0): # ignore header cells
+func _on_cell_right_selected(string_id: StringName, _col: int, _mouse_pos: Vector2) -> void:
+	if string_id != &"":
 		edit_context_menu.popup(Rect2(DisplayServer.mouse_get_position(), Vector2.ZERO))
 
 
-func _on_multiple_rows_selected(_rows: Array) -> void:
-	#print("Multiple row selected : ", rows)
+func _on_multiple_rows_selected(_ids: Array[StringName]) -> void:
 	pass
 
 
-func _on_cell_edited(row: int, column: int, old_value: Variant, new_value: Variant) -> void:
+func _on_cell_edited(string_id: StringName, column: int, old_value: Variant, new_value: Variant) -> void:
 	if column not in [UID_COLUMN, STRINGID_COLUMN]:
-		var entry := get_row_resource_uid(row)
 		var col_config: DynamicTable.ColumnConfig = dynamic_table.get_column(column)
 		var prop_name: StringName = col_config.identifier
-		if RegistryIO.is_uid_valid(entry):
-			_edit_entry_property(entry, prop_name, old_value, new_value)
+		var uid := current_registry.get_uid(string_id)
+		if RegistryIO.is_uid_valid(uid):
+			_edit_entry_property(uid, prop_name, old_value, new_value)
 	elif column == STRINGID_COLUMN and new_value:
-		RegistryIO.rename_entry(current_registry, old_value, new_value)
+		RegistryIO.rename_entry(current_registry, string_id, new_value)
 	elif column == UID_COLUMN and new_value:
-		var old_uid := get_row_resource_uid(row) # Needed because the cell might store uid://<invalid>
-		RegistryIO.change_entry_uid(current_registry, old_uid, new_value)
+		var uid := current_registry.get_uid(string_id)
+		RegistryIO.change_entry_uid(current_registry, uid, new_value)
 	update_view()
-
-
-func _on_header_clicked(_column: int) -> void:
-	#print("Header clicked on column ", column)
-	pass
 
 
 func _on_column_resized(column: int, new_width: float) -> void:


### PR DESCRIPTION
## Description

Row and column indices used for rendering are now fully internal to DynamicTable, which exposes identifiers in its signals and requires them in factory methods.

This removes the need in RegistryTableView for brittle maps of
* row index -> registry entry
* column index -> class property

This should also make #93 simpler to implement.

A larger refactor of the behemoth that is DynamicTable is still needed, since it is quite a pain to work with in its current state. At 2,100 lines, it should probably be split up.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
