### PR TITLE
feat: freeze arbitrary columns and add per-column hide/freeze menu

### DIFF
--- a/addons/yard/editor_only/classes/data_table/column_config.gd
+++ b/addons/yard/editor_only/classes/data_table/column_config.gd
@@ -44,6 +44,7 @@ var minimum_width: float:
 var current_width: float:
 	set(value):
 		current_width = max(value, minimum_width)
+var frozen: bool = false
 
 var _cache: Dictionary = { }
 

--- a/addons/yard/editor_only/classes/data_table/data_table.gd
+++ b/addons/yard/editor_only/classes/data_table/data_table.gd
@@ -24,8 +24,6 @@ const ClassUtils := Namespace.ClassUtils
 const YardLogger := Namespace.YardLogger
 const AnyIcon := Namespace.AnyIcon
 
-const CELL_INVALID := "<CELL_INVALID>"
-
 # Theming properties
 @export_group("Default color")
 @export var default_font_color: Color = Color(1.0, 1.0, 1.0)
@@ -36,7 +34,6 @@ const CELL_INVALID := "<CELL_INVALID>"
 @export_group("Size and grid")
 @export var default_minimum_column_width: float = 50.0
 @export var row_height: float = 30.0
-@export var n_frozen_columns: int = 0
 @export var grid_color: Color = Color(0.8, 0.8, 0.8)
 @export_group("Rows")
 @export var selected_row_back_color: Color = Color(0.0, 0.0, 1.0, 0.5)
@@ -67,15 +64,16 @@ var sort_column: StringName = &""
 var sort_ascending: bool = true
 
 # Row model: key -> cells (the data), and the current display order
-var _rows: Dictionary[StringName, Array] = { }
+var _rows: Dictionary[StringName, Dictionary] = { }
 var _base_order: Array[StringName] = [] # insertion order, source for filter
 var _order: Array[StringName] = [] # current visible filtered / sorted order
 var _anchor_row: StringName = &"" # shift-select range anchor
 
-# Column model: the ordered list is both the model and the display order
-# (no column reordering feature exists). The map is a position cache.
-var _columns: Array[ColumnConfig]
-var _column_index_by_id: Dictionary[StringName, int] = { }
+# Column model.
+var _column_base_order: Array[ColumnConfig] = []
+var _columns: Array[ColumnConfig] = []
+var _column_index_by_id: Dictionary[StringName, int] = { } # Position cache into _columns.
+var n_frozen_columns: int = 0 ## Derived value
 
 # Scrolling
 var _h_scroll: HScrollBar
@@ -270,10 +268,8 @@ func set_native_theming(delay: int = 0) -> void:
 
 
 func set_columns(columns: Array[ColumnConfig]) -> void:
-	_columns = columns
-	_column_index_by_id.clear()
-	for i in _columns.size():
-		_column_index_by_id[_columns[i].identifier] = i
+	_column_base_order = columns
+	_rebuild_display_columns()
 	_reset_column_widths()
 	queue_redraw()
 
@@ -288,29 +284,30 @@ func get_all_columns() -> Array[ColumnConfig]:
 	return _columns.duplicate()
 
 
-func _column_index(col: StringName) -> int:
-	return _column_index_by_id.get(col, -1)
+## Toggles freeze on a single column by identifier, preserving relative order
+## within both the frozen and scrollable groups. No-op if the column doesn't exist.
+func set_column_frozen(identifier: StringName, frozen: bool) -> void:
+	var column := get_column(identifier)
+	if not column or column.frozen == frozen:
+		return
+	column.frozen = frozen
+	_rebuild_display_columns()
+	refresh_layout()
 
 
 ## Replace all rows. Preserves focused_row and selected_rows for keys that still exist.
 ## Re-applies the active filter and sort after rebuilding.
-func set_data(rows: Array, row_ids: Array[StringName]) -> void:
+func set_data(rows: Array[Dictionary], row_ids: Array[StringName]) -> void:
 	_rows.clear()
 	_base_order.clear()
 	for i in row_ids.size():
-		var row := row_ids[i]
-		_rows[row] = rows[i].duplicate() if i < rows.size() else []
-		_base_order.append(row)
+		var row_id := row_ids[i]
+		_rows[row_id] = rows[i].duplicate() if i < rows.size() else { }
+		_base_order.append(row_id)
 	_order = _base_order.duplicate()
 	_rebuild_filtered_order()
 
 	_visible_rows_range = [0, min(_order.size(), floori(size.y / row_height) if row_height > 0 else 0)]
-
-	# Pad short rows
-	for row in _order:
-		var row_data: Array = _rows[row]
-		while row_data.size() < _columns.size():
-			row_data.append(CELL_INVALID)
 
 	# Preserve selection / focus for rows that still exist
 	var kept_rows: Array[StringName] = []
@@ -333,22 +330,18 @@ func set_data(rows: Array, row_ids: Array[StringName]) -> void:
 
 
 ## Update a single row in place without rebuilding the full dataset.
-func update_row(row: StringName, cells: Array) -> void:
+func update_row(row: StringName, cells: Dictionary[StringName, Variant]) -> void:
 	if not _rows.has(row):
 		return
 	_rows[row] = cells.duplicate()
-	while _rows[row].size() < _columns.size():
-		_rows[row].append(CELL_INVALID)
 	queue_redraw()
 
 
 ## Append a new row. No-op if the row already exists.
-func add_row(row: StringName, cells: Array) -> void:
+func add_row(row: StringName, cells: Dictionary[StringName, Variant]) -> void:
 	if _rows.has(row):
 		return
 	_rows[row] = cells.duplicate()
-	while _rows[row].size() < _columns.size():
-		_rows[row].append(CELL_INVALID)
 	_base_order.append(row)
 	_order.append(row)
 	_update_scrollbars()
@@ -379,16 +372,15 @@ func ordering_data(column: StringName, ascending: bool = true) -> void:
 	_finish_editing(false)
 	sort_column = column
 	sort_ascending = ascending
-	var column_idx := _column_index(column)
 	_icon_sort = " ▼ " if ascending else " ▲ "
 	var handler := column_cfg.get_cell_type()
 
 	_order.sort_custom(
 		func(a: StringName, b: StringName) -> bool:
-			var a_cells: Array = _rows.get(a, [])
-			var b_cells: Array = _rows.get(b, [])
-			var va: Variant = a_cells[column_idx] if column_idx < a_cells.size() else null
-			var vb: Variant = b_cells[column_idx] if column_idx < b_cells.size() else null
+			var a_cells: Dictionary[StringName, Variant] = _rows.get(a, { })
+			var b_cells: Dictionary[StringName, Variant] = _rows.get(b, { })
+			var va: Variant = a_cells.get(column, null)
+			var vb: Variant = b_cells.get(column, null)
 			var ka: Variant = handler.get_sort_key(va, column_cfg) if va != null else null
 			var kb: Variant = handler.get_sort_key(vb, column_cfg) if vb != null else null
 			if ka == null and kb == null:
@@ -412,20 +404,16 @@ func ordering_data(column: StringName, ascending: bool = true) -> void:
 
 
 func update_cell(row: StringName, col: StringName, value: Variant) -> void:
-	var col_idx := _column_index(col)
-	if not _rows.has(row) or col_idx < 0:
+	if not is_cell_valid(row, col):
 		return
-	while _rows[row].size() <= col_idx:
-		_rows[row].append(CELL_INVALID)
-	_rows[row][col_idx] = value
+	_rows[row][col] = value
 	queue_redraw()
 
 
 func get_cell_value(row: StringName, col: StringName) -> Variant:
-	var col_idx := _column_index(col)
-	if not _rows.has(row) or col_idx < 0 or col_idx >= _rows[row].size():
+	if not is_cell_valid(row, col):
 		return null
-	return _rows[row][col_idx]
+	return _rows[row][col]
 
 
 func set_selected_cell(row: StringName, col: StringName) -> void:
@@ -462,12 +450,8 @@ func select_all_rows() -> void:
 	_ensure_col_visible(focused_col)
 
 
-func is_cell_invalid(row: StringName, col: StringName) -> bool:
-	var col_idx := _column_index(col)
-	if not _rows.has(row) or col_idx < 0 or col_idx >= _rows[row].size():
-		return false
-	var raw_value: Variant = _rows[row][col_idx]
-	return raw_value is String and raw_value == CELL_INVALID
+func is_cell_valid(row: StringName, col: StringName) -> bool:
+	return _rows.has(row) and _rows[row].has(col)
 
 
 ## Returns the rows currently visible (after sort/filter), in display order.
@@ -482,7 +466,8 @@ func clear_filter() -> void:
 	_filter_text = ""
 
 
-## Call after changing n_frozen_columns or other layout properties.
+## Call after changing column widths or other layout properties. (Freeze
+## changes via set_column_frozen()/set_columns() already call this.)
 func refresh_layout() -> void:
 	_update_scrollbars()
 	queue_redraw()
@@ -549,6 +534,18 @@ func _reset_column_widths() -> void:
 		column.current_width = header_size.x
 
 
+func _rebuild_display_columns() -> void:
+	var frozen_cols: Array[ColumnConfig] = []
+	var scrollable_cols: Array[ColumnConfig] = []
+	for col in _column_base_order:
+		(frozen_cols if col.frozen else scrollable_cols).append(col)
+	_columns = frozen_cols + scrollable_cols
+	n_frozen_columns = frozen_cols.size()
+	_column_index_by_id.clear()
+	for i in _columns.size():
+		_column_index_by_id[_columns[i].identifier] = i
+
+
 func _update_scrollbars() -> void:
 	if not is_inside_tree():
 		return
@@ -584,6 +581,10 @@ func _update_scrollbars() -> void:
 	_on_v_scroll_value_changed(_v_scroll.value)
 
 
+func _get_column_index(col: StringName) -> int:
+	return _column_index_by_id.get(col, -1)
+
+
 func _is_numeric_value(value: Variant) -> bool:
 	if value == null:
 		return false
@@ -592,7 +593,7 @@ func _is_numeric_value(value: Variant) -> bool:
 
 
 func _start_cell_editing(row: StringName, col: StringName) -> void:
-	if is_cell_invalid(row, col):
+	if not is_cell_valid(row, col):
 		return
 
 	var column := get_column(col)
@@ -634,7 +635,7 @@ func _finish_editing(save_changes: bool = true) -> void:
 
 func _get_cell_rect(row: StringName, col: StringName) -> Rect2:
 	var row_idx := _order.find(row)
-	var col_idx := _column_index(col)
+	var col_idx := _get_column_index(col)
 	if row_idx < _visible_rows_range[0] or row_idx >= _visible_rows_range[1] or col_idx < 0:
 		return Rect2()
 	var cell_x := _get_col_x_pos(col_idx)
@@ -647,7 +648,7 @@ func _get_cell_rect(row: StringName, col: StringName) -> Rect2:
 
 
 func _dispatch_cell_draw(cell_rect: Rect2, row: StringName, col: StringName) -> void:
-	if is_cell_invalid(row, col):
+	if not is_cell_valid(row, col):
 		draw_rect(cell_rect, invalid_cell_color, true)
 		return
 	var column := get_column(col)
@@ -751,7 +752,7 @@ func _start_filtering(col: StringName) -> void:
 	if _filtered_column == col and _filter_line_edit.visible:
 		return
 
-	var col_idx := _column_index(col)
+	var col_idx := _get_column_index(col)
 	var col_x := _get_col_x_pos(col_idx)
 	var header_rect := Rect2(col_x, 0, get_column(col).current_width, header_height)
 	_filtered_column = col
@@ -799,12 +800,11 @@ func _rebuild_filtered_order() -> void:
 		_order = _base_order.duplicate()
 		return
 	_order.clear()
-	var col_idx := _column_index(_filtered_column)
 	var key_lower := _filter_text.to_lower()
 	for row in _base_order:
-		var row_data: Array = _rows.get(row, [])
-		if col_idx >= 0 and col_idx < row_data.size() and row_data[col_idx] != null:
-			if str(row_data[col_idx]).to_lower().contains(key_lower):
+		var row_data: Dictionary[StringName, Dictionary] = _rows.get(row, { })
+		if is_cell_valid(row, _filtered_column):
+			if str(row_data[_filtered_column]).to_lower().contains(key_lower):
 				_order.append(row)
 
 
@@ -924,7 +924,7 @@ func _ensure_row_visible(row: StringName) -> void:
 
 
 func _ensure_col_visible(col: StringName) -> void:
-	var col_idx := _column_index(col)
+	var col_idx := _get_column_index(col)
 	if _columns.is_empty() or col_idx < 0 or not _h_scroll.visible:
 		return
 	if col_idx < n_frozen_columns:
@@ -1179,7 +1179,7 @@ func _handle_key_input(event: InputEventKey) -> void:
 	var is_cell_focused := focused_row != &"" and focused_col != &""
 
 	var focused_idx := _order.find(focused_row) if focused_row != &"" else -1
-	var focused_col_idx := _column_index(focused_col) if focused_col != &"" else -1
+	var focused_col_idx := _get_column_index(focused_col) if focused_col != &"" else -1
 	var new_idx := focused_idx
 	var new_col_idx := focused_col_idx
 

--- a/addons/yard/editor_only/classes/yard_editor_cache.gd
+++ b/addons/yard/editor_only/classes/yard_editor_cache.gd
@@ -8,7 +8,7 @@ const _BASE_DIR := "res://.godot/plugins/yard/"
 
 
 class RegistryCacheData:
-	const _REGISTRY_CACHE_VERSION := 2
+	const _REGISTRY_CACHE_VERSION := 3
 	const _REGISTRIES_DIR := _BASE_DIR + "registries/"
 	const _SECTION_GENERAL := "general"
 	const _SECTION_TABLE := "table"
@@ -21,6 +21,7 @@ class RegistryCacheData:
 	]
 	var version: int = _REGISTRY_CACHE_VERSION
 	var disabled_columns: Array[StringName] = BUILTIN_RESOURCE_PROPERTIES.duplicate()
+	var frozen_columns: Array[StringName] = [&"string_id", &"uid"] # duplicated literals: RegistryTableView.STRINGID_COLUMN / UID_COLUMN
 	var parent_props_first: bool = false
 	var uid_column_width: float = 200.0
 	var string_id_column_width: float = 200.0
@@ -37,6 +38,7 @@ class RegistryCacheData:
 		var cfg := ConfigFile.new()
 		cfg.set_value(_SECTION_GENERAL, "version", version)
 		cfg.set_value(_SECTION_TABLE, "disabled_columns", disabled_columns)
+		cfg.set_value(_SECTION_TABLE, "frozen_columns", frozen_columns)
 		cfg.set_value(_SECTION_TABLE, "parent_props_first", parent_props_first)
 		cfg.set_value(_SECTION_TABLE, "uid_column_width", uid_column_width)
 		cfg.set_value(_SECTION_TABLE, "string_id_column_width", string_id_column_width)
@@ -57,6 +59,7 @@ class RegistryCacheData:
 			RegistryCacheData._update_format(data, cfg)
 
 		data.disabled_columns = cfg.get_value(_SECTION_TABLE, "disabled_columns", data.disabled_columns)
+		data.frozen_columns = cfg.get_value(_SECTION_TABLE, "frozen_columns", data.frozen_columns)
 		data.parent_props_first = cfg.get_value(_SECTION_TABLE, "parent_props_first", data.parent_props_first)
 		data.uid_column_width = cfg.get_value(_SECTION_TABLE, "uid_column_width", data.uid_column_width)
 		data.string_id_column_width = cfg.get_value(_SECTION_TABLE, "string_id_column_width", data.string_id_column_width)
@@ -81,6 +84,10 @@ class RegistryCacheData:
 		if _data.version < 2:
 			_data.parent_props_first = false
 			_data.version = 2
+
+		if _data.version < 3:
+			_data.frozen_columns = [&"string_id", &"uid"]
+			_data.version = 3
 
 		_data.version = _REGISTRY_CACHE_VERSION
 

--- a/addons/yard/editor_only/locale/de_DE.po
+++ b/addons/yard/editor_only/locale/de_DE.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "Dateibereich ein-/ausblenden"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "Text-ID"
 
@@ -300,12 +301,20 @@ msgid "Select a registry first"
 msgstr "Zuerst eine Registrierung auswählen"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "ID-Spalten fixieren"
+msgid "ID Columns"
+msgstr "ID-Spalten"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "Hält die Spalten UID und Text-ID beim horizontalen Scrollen sichtbar."
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "Ausgeblendet"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "Fixiert"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/locale/en_US.po
+++ b/addons/yard/editor_only/locale/en_US.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "Toggle Files Panel"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "String ID"
 
@@ -291,12 +292,20 @@ msgid "Select a registry first"
 msgstr "Select a registry first"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "Freeze ID Columns"
+msgid "ID Columns"
+msgstr "ID Columns"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "Keep the UID and string ID columns visible while scrolling horizontally."
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "Hidden"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "Frozen"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/locale/es_ES.po
+++ b/addons/yard/editor_only/locale/es_ES.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "Mostrar/ocultar panel de archivos"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "ID textual"
 
@@ -300,12 +301,20 @@ msgid "Select a registry first"
 msgstr "Seleccione primero un registro"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "Fijar columnas de ID"
+msgid "ID Columns"
+msgstr "Columnas de ID"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "Mantiene las columnas UID e ID textual visibles al desplazarse horizontalmente."
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "Oculto"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "Fijado"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/locale/fr_FR.po
+++ b/addons/yard/editor_only/locale/fr_FR.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "Afficher/masquer le panneau de fichiers"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "ID textuel"
 
@@ -300,12 +301,20 @@ msgid "Select a registry first"
 msgstr "Sélectionnez d'abord un registre"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "Figer les colonnes d'ID"
+msgid "ID Columns"
+msgstr "Colonnes d'ID"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "Garde les colonnes UID et ID visibles lors du défilement horizontal."
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "Masqué"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "Figé"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/locale/it_IT.po
+++ b/addons/yard/editor_only/locale/it_IT.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "Mostra/nascondi pannello file"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "ID testuale"
 
@@ -297,12 +298,20 @@ msgid "Select a registry first"
 msgstr "Seleziona prima un registro"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "Blocca colonne ID"
+msgid "ID Columns"
+msgstr "Colonne ID"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "Mantiene visibili le colonne UID e ID testuale durante lo scorrimento orizzontale."
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "Nascosto"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "Bloccato"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/locale/pl_PL.po
+++ b/addons/yard/editor_only/locale/pl_PL.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "Pokaż/ukryj panel plików"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "ID tekstowe"
 
@@ -293,12 +294,20 @@ msgid "Select a registry first"
 msgstr "Najpierw wybierz rejestr"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "Zablokuj kolumny ID"
+msgid "ID Columns"
+msgstr "Kolumny ID"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "Utrzymuje widoczność kolumn UID i ID tekstowego podczas przewijania poziomego."
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "Ukryte"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "Zablokowane"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/locale/plugin.pot
+++ b/addons/yard/editor_only/locale/plugin.pot
@@ -81,6 +81,7 @@ msgid "Toggle Files Panel"
 msgstr ""
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr ""
 
@@ -269,11 +270,19 @@ msgid "Select a registry first"
 msgstr ""
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
+msgid "ID Columns"
 msgstr ""
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
+msgid "UID"
+msgstr ""
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr ""
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
 msgstr ""
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd

--- a/addons/yard/editor_only/locale/pt_BR.po
+++ b/addons/yard/editor_only/locale/pt_BR.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "Mostrar/ocultar painel de arquivos"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "ID textual"
 
@@ -299,12 +300,20 @@ msgid "Select a registry first"
 msgstr "Selecione um registro primeiro"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "Fixar colunas de ID"
+msgid "ID Columns"
+msgstr "Colunas de ID"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "Mantém as colunas UID e ID textual visíveis ao rolar horizontalmente."
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "Oculto"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "Fixado"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/locale/ru_RU.po
+++ b/addons/yard/editor_only/locale/ru_RU.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "Показать/скрыть панель файлов"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "Строковый ID"
 
@@ -294,12 +295,20 @@ msgid "Select a registry first"
 msgstr "Сначала выберите реестр"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "Закрепить столбцы ID"
+msgid "ID Columns"
+msgstr "Столбцы ID"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "Сохраняет видимость столбцов UID и строкового ID при горизонтальной прокрутке."
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "Скрыто"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "Закреплено"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/locale/tr_TR.po
+++ b/addons/yard/editor_only/locale/tr_TR.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "Dosya panelini göster/gizle"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "Metin ID"
 
@@ -295,12 +296,20 @@ msgid "Select a registry first"
 msgstr "Önce bir kayıt defteri seçin"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "ID sütunlarını sabitle"
+msgid "ID Columns"
+msgstr "ID Sütunları"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "Yatay kaydırma sırasında UID ve Metin ID sütunlarını görünür tutar."
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "Gizli"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "Sabit"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/locale/zh_CN.po
+++ b/addons/yard/editor_only/locale/zh_CN.po
@@ -78,6 +78,7 @@ msgid "Toggle Files Panel"
 msgstr "显示/隐藏文件面板"
 
 #: addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "String ID"
 msgstr "字符串 ID"
 
@@ -282,12 +283,20 @@ msgid "Select a registry first"
 msgstr "请先选择一个注册表"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Freeze ID Columns"
-msgstr "固定 ID 列"
+msgid "ID Columns"
+msgstr "ID 列"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
-msgid "Keep the UID and string ID columns visible while scrolling horizontally."
-msgstr "在水平滚动时保持 UID 和字符串 ID 列可见。"
+msgid "UID"
+msgstr "UID"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Hidden"
+msgstr "隐藏"
+
+#: addons/yard/editor_only/ui_scenes/registry_editor.gd
+msgid "Frozen"
+msgstr "固定"
 
 #: addons/yard/editor_only/ui_scenes/registry_editor.gd
 msgid "Show Parent Properties First"

--- a/addons/yard/editor_only/ui_scenes/registry_editor.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_editor.gd
@@ -20,6 +20,7 @@ enum FileMenuAction {
 	SORT = 32,
 	CLEAR_RECENT = 40,
 }
+const ColumnMenuAction := RegistryTableView.ColumnMenuAction # Enum
 const EditMenuAction := RegistryTableView.EditMenuAction # Enum
 
 const Namespace := preload("res://addons/yard/editor_only/namespace.gd")
@@ -36,6 +37,8 @@ const FuzzySearch := Namespace.FuzzySearch
 const YardLogger := Namespace.YardLogger
 const FuzzySearchResult := FuzzySearch.FuzzySearchResult
 const BUILTIN_RESOURCE_PROPERTIES: Array[StringName] = RegistryCacheData.BUILTIN_RESOURCE_PROPERTIES
+const STRINGID_COLUMN := RegistryTableView.STRINGID_COLUMN
+const UID_COLUMN := RegistryTableView.UID_COLUMN
 
 const ACCELERATORS_WIN: Dictionary = {
 	FileMenuAction.NEW: KEY_MASK_CTRL | KEY_N,
@@ -435,18 +438,12 @@ func _populate_open_recent_submenu() -> void:
 
 func _populate_columns_popup_menu() -> void:
 	var popup := columns_menu_button.get_popup()
-	popup.clear()
+	popup.clear(true)
+	# free_submenus=true, avoids leaking a PopupMenu Node per column per open
 
 	if not registry_table_view.current_registry:
 		popup.add_separator("Select a registry first")
 		return
-
-	_add_check_item(
-		popup,
-		tr("Freeze ID Columns"),
-		tr("Keep the UID and string ID columns visible while scrolling horizontally."),
-		registry_table_view.id_columns_frozen,
-	)
 
 	_add_check_item(
 		popup,
@@ -457,6 +454,11 @@ func _populate_columns_popup_menu() -> void:
 		),
 		registry_table_view.current_cache_data.parent_props_first,
 	)
+
+	popup.add_separator(tr("ID Columns"))
+	popup.set_item_auto_translate_mode(popup.item_count - 1, AUTO_TRANSLATE_MODE_DISABLED)
+	_add_column_submenu_item(popup, STRINGID_COLUMN, tr("String ID"), { }, false)
+	_add_column_submenu_item(popup, UID_COLUMN, tr("UID"), { }, false)
 
 	if not registry_table_view.properties_column_info:
 		return
@@ -470,13 +472,13 @@ func _populate_columns_popup_menu() -> void:
 				popup.add_separator(separator_label)
 				popup.set_item_auto_translate_mode(popup.item_count - 1, AUTO_TRANSLATE_MODE_DISABLED)
 		elif prop_name not in BUILTIN_RESOURCE_PROPERTIES:
-			_add_column_check_item(popup, prop)
+			_add_column_submenu_item(popup, prop_name, prop_name.capitalize(), prop)
 
 	popup.add_separator("Resource/RefCounted")
 	popup.set_item_auto_translate_mode(popup.item_count - 1, AUTO_TRANSLATE_MODE_DISABLED)
 	for prop: Dictionary in registry_table_view.properties_column_info:
 		if prop[&"name"] in BUILTIN_RESOURCE_PROPERTIES:
-			_add_column_check_item(popup, prop)
+			_add_column_submenu_item(popup, prop[&"name"], String(prop[&"name"]).capitalize(), prop)
 
 
 func _add_check_item(popup: PopupMenu, label: String, tooltip: String, checked: bool) -> void:
@@ -486,14 +488,31 @@ func _add_check_item(popup: PopupMenu, label: String, tooltip: String, checked: 
 	popup.set_item_checked(idx, checked)
 
 
-func _add_column_check_item(popup: PopupMenu, prop: Dictionary) -> void:
-	var prop_name: String = prop[&"name"]
-	popup.add_check_item(prop_name.capitalize())
+func _add_column_submenu_item(popup: PopupMenu, identifier: StringName, label: String, prop: Dictionary = { }, include_hide: bool = true) -> void:
+	popup.add_submenu_node_item(label, _build_column_submenu(identifier, include_hide))
 	var idx := popup.item_count - 1
-	popup.set_item_auto_translate_mode(idx, AUTO_TRANSLATE_MODE_DISABLED)
-	popup.set_item_tooltip(idx, prop_name)
-	popup.set_item_icon(idx, AnyIcon.get_property_icon_from_dict(prop))
-	popup.set_item_checked(idx, prop_name not in registry_table_view.current_cache_data.disabled_columns)
+	popup.set_item_tooltip(idx, str(identifier))
+	if not prop.is_empty():
+		popup.set_item_auto_translate_mode(idx, AUTO_TRANSLATE_MODE_DISABLED)
+		popup.set_item_icon(idx, AnyIcon.get_property_icon_from_dict(prop))
+
+
+func _build_column_submenu(identifier: StringName, include_hide: bool) -> PopupMenu:
+	var submenu := PopupMenu.new()
+	submenu.hide_on_checkable_item_selection = false
+	if include_hide:
+		submenu.add_check_item(tr("Hidden"), ColumnMenuAction.HIDDEN)
+		submenu.set_item_checked(
+			submenu.get_item_index(ColumnMenuAction.HIDDEN),
+			identifier in registry_table_view.current_cache_data.disabled_columns,
+		)
+	submenu.add_check_item(tr("Frozen"), ColumnMenuAction.FROZEN)
+	submenu.set_item_checked(
+		submenu.get_item_index(ColumnMenuAction.FROZEN),
+		identifier in registry_table_view.current_cache_data.frozen_columns,
+	)
+	submenu.id_pressed.connect(_on_column_submenu_id_pressed.bind(identifier, submenu))
+	return submenu
 
 
 func _do_file_menu_action(action_id: int) -> void:
@@ -651,26 +670,35 @@ func _on_registry_context_menu_id_pressed(id: int) -> void:
 
 func _on_columns_menu_id_pressed(id: int) -> void:
 	var popup := columns_menu_button.get_popup()
-
 	match id:
-		0: # Freeze ID Columns
+		0: # Parent props first
+			var cache := registry_table_view.current_cache_data
 			popup.toggle_item_checked(0)
-			registry_table_view.id_columns_frozen = popup.is_item_checked(0)
-		1: # Parent props first
-			popup.toggle_item_checked(1)
-			registry_table_view.current_cache_data.parent_props_first = popup.is_item_checked(1)
-			registry_table_view.current_cache_data.save()
+			cache.parent_props_first = popup.is_item_checked(0)
+			cache.save()
 			registry_table_view.update_view()
-		_:
-			var prop_name: StringName = popup.get_item_tooltip(id)
-			popup.toggle_item_checked(id)
-			if popup.is_item_checked(id):
-				registry_table_view.current_cache_data.disabled_columns.erase(prop_name)
+
+
+func _on_column_submenu_id_pressed(action_id: int, identifier: StringName, submenu: PopupMenu) -> void:
+	var item_idx := submenu.get_item_index(action_id)
+	submenu.toggle_item_checked(item_idx)
+	var checked := submenu.is_item_checked(item_idx)
+	var cache := registry_table_view.current_cache_data
+	match action_id:
+		ColumnMenuAction.HIDDEN:
+			if checked:
+				if identifier not in cache.disabled_columns:
+					cache.disabled_columns.append(identifier)
 			else:
-				if not prop_name in registry_table_view.current_cache_data.disabled_columns:
-					registry_table_view.current_cache_data.disabled_columns.append(prop_name)
-			registry_table_view.current_cache_data.save()
-			registry_table_view.update_view()
+				cache.disabled_columns.erase(identifier)
+		ColumnMenuAction.FROZEN:
+			if checked:
+				if identifier not in cache.frozen_columns:
+					cache.frozen_columns.append(identifier)
+			else:
+				cache.frozen_columns.erase(identifier)
+	cache.save()
+	registry_table_view.update_view()
 
 
 func _on_itemlist_registries_dropped(registries: Array[Registry]) -> void:
@@ -743,8 +771,8 @@ func _on_toggle_registries_pressed() -> void:
 func _on_new_registry_dialog_settings_saved() -> void:
 	_update_registries_itemlist()
 	if (
-		new_registry_dialog._state == new_registry_dialog.RegistryDialogState.REGISTRY_SETTINGS
-		and new_registry_dialog.edited_registry == registry_table_view.current_registry
+			new_registry_dialog._state == new_registry_dialog.RegistryDialogState.REGISTRY_SETTINGS
+			and new_registry_dialog.edited_registry == registry_table_view.current_registry
 	):
 		select_registry(_current_registry_uid)
 

--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -15,6 +15,10 @@ enum EditMenuAction {
 	INVERT_SELECTION = 10,
 	UNSELECT = 11,
 }
+enum ColumnMenuAction {
+	HIDDEN = 0,
+	FROZEN = 1
+}
 
 const Namespace := preload("res://addons/yard/editor_only/namespace.gd")
 const RegistryIO := Namespace.RegistryIO
@@ -69,12 +73,6 @@ var toggle_button_forward := false:
 	set(forward):
 		var icon_name := &"Forward" if forward else &"Back"
 		toggle_registry_panel_button.icon = get_theme_icon(icon_name, &"EditorIcons")
-
-var id_columns_frozen := true:
-	set(frozen):
-		id_columns_frozen = frozen
-		data_table.n_frozen_columns = 2 if frozen else 0
-		data_table.refresh_layout()
 
 var _texture_rect_parent: Button
 var _res_picker: EditorResourcePicker
@@ -133,7 +131,6 @@ func _ready() -> void:
 
 	grow_horizontal = Control.GROW_DIRECTION_END
 	grow_vertical = Control.GROW_DIRECTION_END
-	id_columns_frozen = id_columns_frozen # to refresh
 
 
 func _process(_delta: float) -> void:
@@ -239,17 +236,18 @@ func update_view() -> void:
 	var resources: Dictionary[StringName, Resource] = current_registry.load_all_blocking()
 	set_columns_data(resources.values())
 
-	var rows: Array[Array] = []
+	var rows: Array[Dictionary] = []
 	var row_ids: Array[StringName] = []
 	for uid in current_registry.get_all_uids():
 		var string_id: StringName = current_registry.get_string_id(uid)
-		var entry_data: Array[Variant] = [string_id]
+		var entry_data: Dictionary[StringName, Variant] = { }
+		entry_data.set(STRINGID_COLUMN, string_id)
 		if RegistryIO.is_uid_valid(uid):
-			entry_data.append(uid)
-			entry_data.append_array(get_res_row_data(current_registry.load_entry(uid)))
+			entry_data.set(UID_COLUMN, uid)
+			entry_data.merge(get_resource_row_data(current_registry.load_entry(uid)))
 		else:
-			entry_data.append(INVALID_UID)
-			entry_data.append_array(get_res_row_data(null))
+			entry_data.set(UID_COLUMN, INVALID_UID)
+			entry_data.merge(get_resource_row_data(null))
 		rows.append(entry_data)
 		row_ids.append(string_id)
 
@@ -296,16 +294,16 @@ func do_edit_menu_action(action_id: int) -> void:
 			_duplicate_selected_entries()
 		EditMenuAction.CUT_CELL_VALUE:
 			var value: Variant = data_table.get_cell_value(focused_row, focused_col)
-			if not data_table.is_cell_invalid(focused_row, focused_col):
+			if data_table.is_cell_valid(focused_row, focused_col):
 				clipboard = value
 				_on_cell_edited(focused_row, focused_col, value, null)
 		EditMenuAction.COPY_CELL_VALUE:
 			var value: Variant = data_table.get_cell_value(focused_row, focused_col)
-			if not data_table.is_cell_invalid(focused_row, focused_col):
+			if data_table.is_cell_valid(focused_row, focused_col):
 				clipboard = value
 		EditMenuAction.PASTE_TO_CELL:
 			var value: Variant = data_table.get_cell_value(focused_row, focused_col)
-			if not data_table.is_cell_invalid(focused_row, focused_col):
+			if data_table.is_cell_valid(focused_row, focused_col):
 				_on_cell_edited(focused_row, focused_col, value, clipboard)
 		EditMenuAction.SELECT_ALL:
 			_select_all()
@@ -335,18 +333,17 @@ func set_columns_data(resources: Array[Resource]) -> void:
 				properties_column_info.append(prop)
 
 
-func get_res_row_data(res: Resource) -> Array[Variant]:
+func get_resource_row_data(res: Resource) -> Dictionary[StringName, Variant]:
 	if properties_column_info.is_empty() or not res:
-		return []
+		return { }
 
-	var row: Array[Variant] = []
+	var row: Dictionary[StringName, Variant] = { }
 	for prop: Dictionary in properties_column_info:
 		if is_property_disabled(prop) or ClassUtils.is_class_property(prop):
 			continue
-		if prop[&"name"] in res:
-			row.append(res.get(prop[&"name"]))
-		else:
-			row.append(DataTable.CELL_INVALID)
+		var prop_name: StringName = prop[&"name"]
+		if prop_name in res:
+			row.set(prop_name, res.get(prop_name))
 	return row
 
 
@@ -355,9 +352,8 @@ func toggle_edit_menu_items(edit_menu: PopupMenu) -> void:
 	var col := data_table.focused_col
 	var has_selected_cell := row != &"" and col != &""
 	var has_selected_row := row != &""
-	var cell_value: Variant = data_table.get_cell_value(row, col) if has_selected_cell else null
 	var cant_be_cut := col in [UID_COLUMN, STRINGID_COLUMN]
-	var is_cell_invalid: bool = cell_value is String and cell_value == data_table.CELL_INVALID
+	var is_cell_invalid: bool = not data_table.is_cell_valid(row, col)
 	edit_menu.set_item_disabled(edit_menu.get_item_index(EditMenuAction.DELETE_ENTRIES), !has_selected_row)
 	edit_menu.set_item_disabled(edit_menu.get_item_index(EditMenuAction.DUPLICATE_ENTRIES), !has_selected_row)
 	edit_menu.set_item_disabled(edit_menu.get_item_index(EditMenuAction.COPY_STRING_ID), !has_selected_row)
@@ -390,11 +386,13 @@ func _build_columns() -> Array[DataTable.ColumnConfig]:
 	var string_id_column: DataTable.ColumnConfig = DataTable.ColumnConfig.new.callv(STRINGID_COLUMN_CONFIG)
 	string_id_column.custom_font_color = get_theme_color(&"accent_color", &"Editor")
 	string_id_column.h_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	string_id_column.frozen = STRINGID_COLUMN in current_cache_data.frozen_columns
 	columns.append(string_id_column)
 
 	var uid_column: DataTable.ColumnConfig = DataTable.ColumnConfig.new.callv(UID_COLUMN_CONFIG)
 	uid_column.custom_font_color = get_theme_color(&"disabled_font_color", &"Editor")
 	uid_column.property_hint = PROPERTY_HINT_FILE
+	uid_column.frozen = UID_COLUMN in current_cache_data.frozen_columns
 	columns.append(uid_column)
 
 	for prop in properties_column_info:
@@ -412,6 +410,7 @@ func _build_columns() -> Array[DataTable.ColumnConfig]:
 			prop_header,
 			prop_type,
 		)
+		column.frozen = column.identifier in current_cache_data.frozen_columns
 
 		if hint:
 			column.property_hint = hint
@@ -457,8 +456,8 @@ func _group_props_by_class(found_props: Dictionary) -> Dictionary[String, Array]
 
 func _can_display_property(property_info: Dictionary) -> bool:
 	return (
-			property_info[&"type"] not in [TYPE_CALLABLE, TYPE_SIGNAL]
-			and property_info[&"usage"] & PROPERTY_USAGE_EDITOR != 0
+		property_info[&"type"] not in [TYPE_CALLABLE, TYPE_SIGNAL]
+		and property_info[&"usage"] & PROPERTY_USAGE_EDITOR != 0
 	)
 
 
@@ -481,10 +480,10 @@ func _edit_entry_property(uid: StringName, property: StringName, old_value: Vari
 	var valid := false
 	for prop_type: String in prop_types:
 		if (
-				(ClassUtils.is_type_builtin(typeof(new_value)) and type_string(typeof(new_value)) == prop_type)
-				or (typeof(new_value) in [TYPE_INT, TYPE_FLOAT] and prop_type in [type_string(TYPE_INT), type_string(TYPE_FLOAT)])
-				or ClassUtils.is_class_of(new_value, prop_type)
-				or (new_value == null and typeof(old_value) == TYPE_OBJECT)
+			(ClassUtils.is_type_builtin(typeof(new_value)) and type_string(typeof(new_value)) == prop_type)
+			or (typeof(new_value) in [TYPE_INT, TYPE_FLOAT] and prop_type in [type_string(TYPE_INT), type_string(TYPE_FLOAT)])
+			or ClassUtils.is_class_of(new_value, prop_type)
+			or (new_value == null and typeof(old_value) == TYPE_OBJECT)
 		):
 			valid = true
 			break
@@ -588,7 +587,7 @@ func _add_entry_from_picker(res: Resource, string_id: StringName) -> void:
 
 func _toggle_add_entry_button() -> void:
 	add_entry_button.disabled = !(
-			_res_picker and _res_picker.edited_resource and entry_name_line_edit.text
+		_res_picker and _res_picker.edited_resource and entry_name_line_edit.text
 	)
 
 

--- a/addons/yard/editor_only/ui_scenes/registry_table_view.tscn
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.tscn
@@ -153,7 +153,6 @@ header_height = 42.0
 header_color = Color(0.14, 0.161, 0.21700001, 1)
 header_filter_active_font_color = Color(0.3372549, 0.61960787, 1, 1)
 row_height = 42.0
-n_frozen_columns = 2
 grid_color = Color(0.14, 0.161, 0.217, 1)
 selected_row_back_color = Color(1, 1, 1, 0.2)
 selected_cell_back_color = Color(0.3372549, 0.61960787, 1, 1)


### PR DESCRIPTION
## Description

You can now freeze any column, not just the first two (String ID / UID). The old "Freeze ID Columns" toggle is gone. Instead, each column in the **Columns** menu now opens a small submenu where you can hide it, freeze it, or both. Frozen columns move to the left, keeping their original relative order.

<img width="315" height="432" alt="Capture d’écran 2026-07-12 à 01 58 04" src="https://github.com/user-attachments/assets/4c57fdd9-9b60-4ec9-abdb-62c37eba3130" />


### Notes
- Freeze/hide choices are remembered per registry.
- Existing registries still start with String ID and UID frozen, so nothing changes for people who never touch the new menu.


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
