### PR TITLE
feat: allow hiding the UID and String ID columns

### DIFF
--- a/addons/yard/editor_only/classes/yard_editor_cache.gd
+++ b/addons/yard/editor_only/classes/yard_editor_cache.gd
@@ -20,8 +20,8 @@ class RegistryCacheData:
 		&"metadata/_custom_type_script",
 	]
 	var version: int = _REGISTRY_CACHE_VERSION
-	var disabled_columns: Array[StringName] = BUILTIN_RESOURCE_PROPERTIES.duplicate()
-	var frozen_columns: Array[StringName] = [&"string_id", &"uid"] # duplicated literals: RegistryTableView.STRINGID_COLUMN / UID_COLUMN
+	var disabled_columns: Array[StringName] = BUILTIN_RESOURCE_PROPERTIES.duplicate() # = hidden columns
+	var frozen_columns: Array[StringName] = [&"string_id", &"uid"]
 	var parent_props_first: bool = false
 	var uid_column_width: float = 200.0
 	var string_id_column_width: float = 200.0

--- a/addons/yard/editor_only/ui_scenes/registry_editor.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_editor.gd
@@ -457,8 +457,8 @@ func _populate_columns_popup_menu() -> void:
 
 	popup.add_separator(tr("ID Columns"))
 	popup.set_item_auto_translate_mode(popup.item_count - 1, AUTO_TRANSLATE_MODE_DISABLED)
-	_add_column_submenu_item(popup, STRINGID_COLUMN, tr("String ID"), { }, false)
-	_add_column_submenu_item(popup, UID_COLUMN, tr("UID"), { }, false)
+	_add_column_submenu_item(popup, STRINGID_COLUMN, tr("String ID"), { })
+	_add_column_submenu_item(popup, UID_COLUMN, tr("UID"), { })
 
 	if not registry_table_view.properties_column_info:
 		return
@@ -488,8 +488,8 @@ func _add_check_item(popup: PopupMenu, label: String, tooltip: String, checked: 
 	popup.set_item_checked(idx, checked)
 
 
-func _add_column_submenu_item(popup: PopupMenu, identifier: StringName, label: String, prop: Dictionary = { }, include_hide: bool = true) -> void:
-	popup.add_submenu_node_item(label, _build_column_submenu(identifier, include_hide))
+func _add_column_submenu_item(popup: PopupMenu, identifier: StringName, label: String, prop: Dictionary = { }) -> void:
+	popup.add_submenu_node_item(label, _build_column_submenu(identifier))
 	var idx := popup.item_count - 1
 	popup.set_item_tooltip(idx, str(identifier))
 	if not prop.is_empty():
@@ -497,15 +497,14 @@ func _add_column_submenu_item(popup: PopupMenu, identifier: StringName, label: S
 		popup.set_item_icon(idx, AnyIcon.get_property_icon_from_dict(prop))
 
 
-func _build_column_submenu(identifier: StringName, include_hide: bool) -> PopupMenu:
+func _build_column_submenu(identifier: StringName) -> PopupMenu:
 	var submenu := PopupMenu.new()
 	submenu.hide_on_checkable_item_selection = false
-	if include_hide:
-		submenu.add_check_item(tr("Hidden"), ColumnMenuAction.HIDDEN)
-		submenu.set_item_checked(
-			submenu.get_item_index(ColumnMenuAction.HIDDEN),
-			identifier in registry_table_view.current_cache_data.disabled_columns,
-		)
+	submenu.add_check_item(tr("Hidden"), ColumnMenuAction.HIDDEN)
+	submenu.set_item_checked(
+		submenu.get_item_index(ColumnMenuAction.HIDDEN),
+		identifier in registry_table_view.current_cache_data.disabled_columns,
+	)
 	submenu.add_check_item(tr("Frozen"), ColumnMenuAction.FROZEN)
 	submenu.set_item_checked(
 		submenu.get_item_index(ColumnMenuAction.FROZEN),

--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -17,7 +17,7 @@ enum EditMenuAction {
 }
 enum ColumnMenuAction {
 	HIDDEN = 0,
-	FROZEN = 1
+	FROZEN = 1,
 }
 
 const Namespace := preload("res://addons/yard/editor_only/namespace.gd")
@@ -313,8 +313,8 @@ func do_edit_menu_action(action_id: int) -> void:
 			_unselect()
 
 
-func is_property_disabled(property_info: Dictionary) -> bool:
-	return property_info[&"name"] in current_cache_data.disabled_columns
+func is_column_disabled(column_id: StringName) -> bool:
+	return column_id in current_cache_data.disabled_columns
 
 
 func set_columns_data(resources: Array[Resource]) -> void:
@@ -339,9 +339,9 @@ func get_resource_row_data(res: Resource) -> Dictionary[StringName, Variant]:
 
 	var row: Dictionary[StringName, Variant] = { }
 	for prop: Dictionary in properties_column_info:
-		if is_property_disabled(prop) or ClassUtils.is_class_property(prop):
-			continue
 		var prop_name: StringName = prop[&"name"]
+		if is_column_disabled(prop_name) or ClassUtils.is_class_property(prop):
+			continue
 		if prop_name in res:
 			row.set(prop_name, res.get(prop_name))
 	return row
@@ -383,23 +383,25 @@ func toggle_edit_menu_items(edit_menu: PopupMenu) -> void:
 func _build_columns() -> Array[DataTable.ColumnConfig]:
 	var columns: Array[DataTable.ColumnConfig] = []
 
-	var string_id_column: DataTable.ColumnConfig = DataTable.ColumnConfig.new.callv(STRINGID_COLUMN_CONFIG)
-	string_id_column.custom_font_color = get_theme_color(&"accent_color", &"Editor")
-	string_id_column.h_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-	string_id_column.frozen = STRINGID_COLUMN in current_cache_data.frozen_columns
-	columns.append(string_id_column)
+	if not is_column_disabled(STRINGID_COLUMN):
+		var string_id_column: DataTable.ColumnConfig = DataTable.ColumnConfig.new.callv(STRINGID_COLUMN_CONFIG)
+		string_id_column.custom_font_color = get_theme_color(&"accent_color", &"Editor")
+		string_id_column.h_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+		string_id_column.frozen = STRINGID_COLUMN in current_cache_data.frozen_columns
+		columns.append(string_id_column)
 
-	var uid_column: DataTable.ColumnConfig = DataTable.ColumnConfig.new.callv(UID_COLUMN_CONFIG)
-	uid_column.custom_font_color = get_theme_color(&"disabled_font_color", &"Editor")
-	uid_column.property_hint = PROPERTY_HINT_FILE
-	uid_column.frozen = UID_COLUMN in current_cache_data.frozen_columns
-	columns.append(uid_column)
+	if not is_column_disabled(UID_COLUMN):
+		var uid_column: DataTable.ColumnConfig = DataTable.ColumnConfig.new.callv(UID_COLUMN_CONFIG)
+		uid_column.custom_font_color = get_theme_color(&"disabled_font_color", &"Editor")
+		uid_column.property_hint = PROPERTY_HINT_FILE
+		uid_column.frozen = UID_COLUMN in current_cache_data.frozen_columns
+		columns.append(uid_column)
 
 	for prop in properties_column_info:
-		if not _can_display_property(prop) or is_property_disabled(prop):
+		var prop_name: String = prop[&"name"]
+		if not _can_display_property(prop) or is_column_disabled(prop_name):
 			continue
 
-		var prop_name: String = prop[&"name"]
 		var prop_header := prop_name.capitalize()
 		var prop_type: Variant.Type = prop[&"type"]
 		var hint: PropertyHint = prop[&"hint"]


### PR DESCRIPTION
## Description

Supersedes #93 by @hriqsc.
Follow-up on #101.

This one takes advantage of the significant refactor DataTable and RegistryTableView went through, allowing any column to be frozen or hidden.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
