### PR TITLE
feat: add a load_random_entry on registry

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,6 +27,7 @@ GitHub usernames appear in parentheses, or on their own when no other name is av
 ## Developers
 
     Cer0reZ
+    gump (gumpdev)
     Marion Allard (Mar0Lard)
     skison
     Verfeon

--- a/addons/yard/registry.gd
+++ b/addons/yard/registry.gd
@@ -195,6 +195,17 @@ func load_entry(
 	else:
 		return ResourceLoader.load(uid, type_hint, cache_mode)
 
+## Loads an random resource and returns it.
+## Returns [code]null[/code] if the entry does not exist or cannot be loaded.[br][br]
+##
+## [param type_hint] and [param cache_mode] are passed down to
+## [method ResourceLoader.load].
+func load_random_entry(
+		type_hint: String = "",
+		cache_mode: ResourceLoader.CacheMode = ResourceLoader.CACHE_MODE_REUSE,
+) -> Resource:
+	var uid := get_all_uids().pick_random()
+	return load_entry(uid, type_hint, cache_mode)
 
 ## Loads all registered resources in a blocking manner. Returns a dictionary
 ## mapping string IDs to their loaded [Resource] instances.


### PR DESCRIPTION
## Description

This is just a feature to load a random entry on a registry

**Some use case example:** 
When you want to spawn random enemies, you can load it randomly without having to load all of them to make a .pick_random()

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added my name to [AUTHORS.md](../AUTHORS.md) (alphabetical list)
