### PR TITLE
feat: add rich tooltips for color, resource, dict and array cells

### DIFF
--- a/addons/yard/editor_only/classes/data_table/cell_types/cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/cell_type.gd
@@ -140,6 +140,10 @@ static func suppresses_tooltip() -> bool:
 	return false
 
 
+static func get_tooltip(value: Variant) -> String:
+	return var_to_str(value)
+
+
 static func get_sort_key(value: Variant, _column: ColumnConfig) -> Variant:
 	return str(value)
 

--- a/addons/yard/editor_only/classes/data_table/cell_types/cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/cell_type.gd
@@ -140,7 +140,7 @@ static func suppresses_tooltip() -> bool:
 	return false
 
 
-static func get_tooltip(value: Variant) -> String:
+static func get_tooltip(value: Variant, _column: ColumnConfig) -> String:
 	return var_to_str(value)
 
 

--- a/addons/yard/editor_only/classes/data_table/cell_types/collection_cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/collection_cell_type.gd
@@ -21,63 +21,16 @@ const ARRAY_TYPES := [
 
 
 static func matches(column: ColumnConfig) -> bool:
-	return column.type in [TYPE_ARRAY, TYPE_DICTIONARY]
+	return _is_dictionary(column) or _is_array(column)
 
 
 static func draw_cell(canvas: CanvasItem, rect: Rect2, value: Variant, column: ColumnConfig, style: CellStyle) -> void:
-	var text: String
-	if value is not Array and value is not Dictionary:
-		text = str(value) if value != null else ""
-	else:
-		text = _format_collection_text(value, column)
+	var text := _format_collection_text(value, column)
 	draw_text(canvas, rect, text, resolve_font(column, style.font), style.font_size, column.h_alignment, resolve_text_color(column, style))
 
 
-static func get_tooltip(value: Variant) -> String:
-	return _value_to_string_pretty(value, true)
-
-
-static func _format_collection_text(collection: Variant, column: ColumnConfig) -> String:
-	var is_dict := collection is Dictionary
-	var items: Array = (collection as Dictionary).keys() if is_dict else (collection as Array)
-	var keys_map: Dictionary = _get_keys_map(column) if _is_dict_with_enum_keys(column) else { }
-	var values_map: Dictionary = (
-		_get_values_map(column)
-		if _is_dict_with_enum_values(column) or _is_array_with_enum_values(column)
-		else { }
-	)
-	var parts: Array[String] = []
-	for i in mini(items.size(), 3):
-		if is_dict:
-			var key: Variant = items[i]
-			var val: Variant = (collection as Dictionary)[key]
-			parts.append(
-				"%s: %s" % [
-					_format_collection_elem(key, keys_map),
-					_format_collection_elem(val, values_map),
-				],
-			)
-		else:
-			parts.append(_format_collection_elem(items[i], values_map))
-
-	var result := ", ".join(parts)
-	var remaining := items.size() - 3
-	if remaining > 0:
-		result += " and {remaining} more".format({ &"remaining": remaining })
-	return "{ %s }" % result if is_dict else "[%s]" % result
-
-
-static func _format_collection_elem(elem: Variant, enum_map: Dictionary = { }) -> String:
-	if elem is Resource:
-		return "<%s>" % (elem as Resource).resource_path.get_file()
-	if elem is Array:
-		return "Array(%d)" % (elem as Array).size()
-	if elem is Dictionary:
-		return "Dict(%d)" % (elem as Dictionary).size()
-	if elem is int and not enum_map.is_empty():
-		var int_elem := elem as int
-		return enum_map[int_elem] if enum_map.has(int_elem) else "?:%d" % int_elem
-	return str(elem)
+static func get_tooltip(value: Variant, _column: ColumnConfig) -> String:
+	return _value_to_string_pretty(value)
 
 
 static func _is_array(column: ColumnConfig) -> bool:
@@ -132,36 +85,79 @@ static func _get_enum_key_hint_string(column: ColumnConfig) -> String:
 	return _get_dict_key_hint_part(column).split(":", true, 1)[1]
 
 
-## https://github.com/godotengine/godot-proposals/issues/538#issuecomment-2989009057
-static func _value_to_string_pretty(value: Variant, use_var_to_str: bool = false, indent: String = "    ", indent_level: int = 0) -> String:
+static func _format_collection_text(collection: Variant, column: ColumnConfig) -> String:
+	var is_dict := _is_dictionary(column)
+	var items: Array = (collection as Dictionary).keys() if is_dict else (collection as Array)
+	var keys_map: Dictionary = _get_keys_map(column) if _is_dict_with_enum_keys(column) else { }
+	var values_map: Dictionary = (
+		_get_values_map(column)
+		if _is_dict_with_enum_values(column) or _is_array_with_enum_values(column)
+		else { }
+	)
+	var parts: Array[String] = []
+	for i in mini(items.size(), 3):
+		if is_dict:
+			var key: Variant = items[i]
+			var val: Variant = (collection as Dictionary)[key]
+			parts.append(
+				"%s: %s" % [
+					_format_element_text(key, keys_map),
+					_format_element_text(val, values_map),
+				],
+			)
+		else:
+			parts.append(_format_element_text(items[i], values_map))
+
+	var result := ", ".join(parts)
+	var remaining := items.size() - 3
+	if remaining > 0:
+		result += " and {remaining} more".format({ &"remaining": remaining })
+	return "{ %s }" % result if is_dict else "[%s]" % result
+
+
+static func _format_element_text(elem: Variant, enum_map: Dictionary = { }) -> String:
+	if elem is Resource:
+		return "<%s>" % (elem as Resource).resource_path.get_file()
+	if elem is Array:
+		return "Array(%d)" % (elem as Array).size()
+	if elem is Dictionary:
+		return "Dict(%d)" % (elem as Dictionary).size()
+	if elem is int and not enum_map.is_empty():
+		var int_elem := elem as int
+		return enum_map[int_elem] if enum_map.has(int_elem) else "?:%d" % int_elem
+	return var_to_str(elem)
+
+
+# SPDX-SnippetBegin
+# SPDX-SnippetCopyrightText: Copyright 2025 Okxa <https://github.com/godotengine/godot-proposals/issues/538#issuecomment-2989009057>
+#
+# SPDX-License-Identifier: MIT
+static func _value_to_string_pretty(value: Variant, indent_level: int = 0) -> String:
+	const INDENT: String = "    "
 	var formatted: String = ""
 	match typeof(value):
-		TYPE_ARRAY, TYPE_PACKED_BYTE_ARRAY, \
-		TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY, \
-		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY, \
-		TYPE_PACKED_STRING_ARRAY, \
-		TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, TYPE_PACKED_VECTOR4_ARRAY, \
-		TYPE_PACKED_COLOR_ARRAY:
+		var t when t in ARRAY_TYPES:
 			if value.is_empty():
 				formatted += "[]"
 			else:
 				formatted += "[\n"
 				for i: int in value.size():
-					formatted += (indent.repeat(indent_level + 1) +
-						_value_to_string_pretty(value[i], use_var_to_str, indent, indent_level + 1) +
+					formatted += (INDENT.repeat(indent_level + 1) +
+						_value_to_string_pretty(value[i], indent_level + 1) +
 						("," if i < value.size() - 1 else "") + "\n" )
-				formatted += indent.repeat(indent_level) + "]"
+				formatted += INDENT.repeat(indent_level) + "]"
 		TYPE_DICTIONARY:
 			if value.is_empty():
 				formatted += "{}"
 			else:
 				formatted += "{\n"
 				for i: int in value.size():
-					formatted += (indent.repeat(indent_level + 1) +
+					formatted += (INDENT.repeat(indent_level + 1) +
 						"\"" + value.keys()[i] + "\": " +
-						_value_to_string_pretty(value.values()[i], use_var_to_str, indent, indent_level + 1) +
+						_value_to_string_pretty(value.values()[i], indent_level + 1) +
 						("," if i < value.size() - 1 else "") + "\n" )
-				formatted += indent.repeat(indent_level) + "}"
+				formatted += INDENT.repeat(indent_level) + "}"
 		_:
-			formatted += var_to_str(value) if use_var_to_str else str(value)
+			formatted += var_to_str(value)
 	return formatted
+# SPDX-SnippetEnd

--- a/addons/yard/editor_only/classes/data_table/cell_types/collection_cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/collection_cell_type.gd
@@ -5,6 +5,21 @@
 extends "res://addons/yard/editor_only/classes/data_table/cell_types/cell_type.gd"
 ## Array/Dictionary columns. display-only: no custom editor.
 
+const ARRAY_TYPES := [
+	TYPE_ARRAY,
+	TYPE_PACKED_BYTE_ARRAY,
+	TYPE_PACKED_INT32_ARRAY,
+	TYPE_PACKED_INT64_ARRAY,
+	TYPE_PACKED_FLOAT32_ARRAY,
+	TYPE_PACKED_FLOAT64_ARRAY,
+	TYPE_PACKED_STRING_ARRAY,
+	TYPE_PACKED_VECTOR2_ARRAY,
+	TYPE_PACKED_VECTOR3_ARRAY,
+	TYPE_PACKED_VECTOR4_ARRAY,
+	TYPE_PACKED_COLOR_ARRAY,
+]
+
+
 static func matches(column: ColumnConfig) -> bool:
 	return column.type in [TYPE_ARRAY, TYPE_DICTIONARY]
 
@@ -16,6 +31,10 @@ static func draw_cell(canvas: CanvasItem, rect: Rect2, value: Variant, column: C
 	else:
 		text = _format_collection_text(value, column)
 	draw_text(canvas, rect, text, resolve_font(column, style.font), style.font_size, column.h_alignment, resolve_text_color(column, style))
+
+
+static func get_tooltip(value: Variant) -> String:
+	return _value_to_string_pretty(value, true)
 
 
 static func _format_collection_text(collection: Variant, column: ColumnConfig) -> String:
@@ -61,16 +80,24 @@ static func _format_collection_elem(elem: Variant, enum_map: Dictionary = { }) -
 	return str(elem)
 
 
+static func _is_array(column: ColumnConfig) -> bool:
+	return column.type in ARRAY_TYPES
+
+
+static func _is_dictionary(column: ColumnConfig) -> bool:
+	return column.type == TYPE_DICTIONARY
+
+
 static func _is_array_with_enum_values(column: ColumnConfig) -> bool:
 	return column.type == TYPE_ARRAY and column.hint_string and _is_enum_collection_hint(column.hint_string)
 
 
 static func _is_dict_with_enum_keys(column: ColumnConfig) -> bool:
-	return column.type == TYPE_DICTIONARY and column.hint_string and _is_enum_collection_hint(_get_dict_key_hint_part(column))
+	return _is_dictionary(column) and column.hint_string and _is_enum_collection_hint(_get_dict_key_hint_part(column))
 
 
 static func _is_dict_with_enum_values(column: ColumnConfig) -> bool:
-	return column.type == TYPE_DICTIONARY and column.hint_string and _is_enum_collection_hint(_get_dict_value_hint_part(column))
+	return _is_dictionary(column) and column.hint_string and _is_enum_collection_hint(_get_dict_value_hint_part(column))
 
 
 static func _is_enum_collection_hint(hint: String) -> bool:
@@ -96,10 +123,45 @@ static func _get_keys_map(column: ColumnConfig) -> Dictionary:
 static func _get_enum_value_hint_string(column: ColumnConfig) -> String:
 	if column.type == TYPE_ARRAY:
 		return column.hint_string.split(":", true, 1)[1]
-	if column.type == TYPE_DICTIONARY:
+	if _is_dictionary(column):
 		return _get_dict_value_hint_part(column).split(":", true, 1)[1]
 	return column.hint_string
 
 
 static func _get_enum_key_hint_string(column: ColumnConfig) -> String:
 	return _get_dict_key_hint_part(column).split(":", true, 1)[1]
+
+
+## https://github.com/godotengine/godot-proposals/issues/538#issuecomment-2989009057
+static func _value_to_string_pretty(value: Variant, use_var_to_str: bool = false, indent: String = "    ", indent_level: int = 0) -> String:
+	var formatted: String = ""
+	match typeof(value):
+		TYPE_ARRAY, TYPE_PACKED_BYTE_ARRAY, \
+		TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY, \
+		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY, \
+		TYPE_PACKED_STRING_ARRAY, \
+		TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, TYPE_PACKED_VECTOR4_ARRAY, \
+		TYPE_PACKED_COLOR_ARRAY:
+			if value.is_empty():
+				formatted += "[]"
+			else:
+				formatted += "[\n"
+				for i: int in value.size():
+					formatted += (indent.repeat(indent_level + 1) +
+						_value_to_string_pretty(value[i], use_var_to_str, indent, indent_level + 1) +
+						("," if i < value.size() - 1 else "") + "\n" )
+				formatted += indent.repeat(indent_level) + "]"
+		TYPE_DICTIONARY:
+			if value.is_empty():
+				formatted += "{}"
+			else:
+				formatted += "{\n"
+				for i: int in value.size():
+					formatted += (indent.repeat(indent_level + 1) +
+						"\"" + value.keys()[i] + "\": " +
+						_value_to_string_pretty(value.values()[i], use_var_to_str, indent, indent_level + 1) +
+						("," if i < value.size() - 1 else "") + "\n" )
+				formatted += indent.repeat(indent_level) + "}"
+		_:
+			formatted += var_to_str(value) if use_var_to_str else str(value)
+	return formatted

--- a/addons/yard/editor_only/classes/data_table/cell_types/color_cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/color_cell_type.gd
@@ -77,10 +77,10 @@ static func read_editor_value(editor: Node, _column: ColumnConfig) -> Variant:
 	return color_popup.color
 
 
-static func get_tooltip(value: Variant) -> String:
+static func get_tooltip(value: Variant, column: ColumnConfig) -> String:
 	if value is Color:
 		return ("R: %.2f\nG: %.2f\nB: %.2f\nA: %.2f\n" % [value.r, value.g, value.b, value.a])
-	return super(value)
+	return super(value, column)
 
 
 class ColorPopup extends PanelContainer:

--- a/addons/yard/editor_only/classes/data_table/cell_types/color_cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/color_cell_type.gd
@@ -77,6 +77,12 @@ static func read_editor_value(editor: Node, _column: ColumnConfig) -> Variant:
 	return color_popup.color
 
 
+static func get_tooltip(value: Variant) -> String:
+	if value is Color:
+		return ("R: %.2f\nG: %.2f\nB: %.2f\nA: %.2f\n" % [value.r, value.g, value.b, value.a])
+	return super(value)
+
+
 class ColorPopup extends PanelContainer:
 	signal color_selected(color: Color)
 	signal canceled

--- a/addons/yard/editor_only/classes/data_table/cell_types/resource_cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/resource_cell_type.gd
@@ -75,9 +75,9 @@ static func read_editor_value(editor: Node, _column: ColumnConfig) -> Variant:
 	return resource_picker.edited_resource
 
 
-static func get_tooltip(value: Variant) -> String:
+static func get_tooltip(value: Variant, column: ColumnConfig) -> String:
 	if not value:
-		return super(value)
+		return super(value, column)
 
 	var res := value as Resource
 	var lines: Array[String]

--- a/addons/yard/editor_only/classes/data_table/cell_types/resource_cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/resource_cell_type.gd
@@ -7,7 +7,7 @@ extends "res://addons/yard/editor_only/classes/data_table/cell_types/cell_type.g
 ## EditorResourcePicker. Clicking away does not commit; the picker manages
 ## its own commit/cancel through its popup.
 
-const ClassUtils := preload("res://addons/yard/editor_only/classes/class_utils.gd")
+const ClassUtils := Namespace.ClassUtils
 
 
 static func matches(column: ColumnConfig) -> bool:
@@ -73,3 +73,28 @@ static func create_editor(owner: Control, _rect: Rect2, _value: Variant, column:
 static func read_editor_value(editor: Node, _column: ColumnConfig) -> Variant:
 	var resource_picker: EditorResourcePicker = editor
 	return resource_picker.edited_resource
+
+
+static func get_tooltip(value: Variant) -> String:
+	if not value:
+		return super(value)
+
+	var res := value as Resource
+	var lines: Array[String]
+	if not res.is_built_in():
+		lines.append("%s" % res.resource_path)
+	lines.append("Type: %s" % ClassUtils.get_type_name(res))
+	if res is Texture2D:
+		lines.append("Dimensions: %s × %s" % [res.get_width(), res.get_height()])
+	lines.append("Properties:")
+	for prop: Dictionary in res.get_property_list():
+		if _can_display_property(prop):
+			lines.append('    "%s": %s' % [prop.name, var_to_str(res.get(prop.name))])
+	return "\n".join(lines)
+
+
+static func _can_display_property(property_info: Dictionary) -> bool:
+	return (
+		property_info[&"type"] not in [TYPE_CALLABLE, TYPE_SIGNAL]
+		and property_info[&"usage"] & PROPERTY_USAGE_EDITOR != 0
+	)

--- a/addons/yard/editor_only/classes/data_table/data_table.gd
+++ b/addons/yard/editor_only/classes/data_table/data_table.gd
@@ -898,9 +898,9 @@ func _update_tooltip(mouse_pos: Vector2) -> void:
 		if row_idx >= 0:
 			new_row = _order[row_idx]
 			new_col = col
-			var column := get_column(col)
-			if not column.get_cell_type().suppresses_tooltip():
-				new_tooltip = str(get_cell_value(new_row, col))
+			var cell_type := get_column(col).get_cell_type()
+			if not cell_type.suppresses_tooltip():
+				new_tooltip = cell_type.get_tooltip(get_cell_value(new_row, col))
 
 	if new_row != _tooltip_row or new_col != _tooltip_col:
 		_tooltip_row = new_row

--- a/addons/yard/editor_only/classes/data_table/data_table.gd
+++ b/addons/yard/editor_only/classes/data_table/data_table.gd
@@ -898,9 +898,10 @@ func _update_tooltip(mouse_pos: Vector2) -> void:
 		if row_idx >= 0:
 			new_row = _order[row_idx]
 			new_col = col
-			var cell_type := get_column(col).get_cell_type()
+			var column := get_column(col)
+			var cell_type := column.get_cell_type()
 			if not cell_type.suppresses_tooltip():
-				new_tooltip = cell_type.get_tooltip(get_cell_value(new_row, col))
+				new_tooltip = cell_type.get_tooltip(get_cell_value(new_row, col), column)
 
 	if new_row != _tooltip_row or new_col != _tooltip_col:
 		_tooltip_row = new_row


### PR DESCRIPTION
## Description

<img width="467" height="224" alt="Capture d’écran 2026-08-17 à 11 49 22" src="https://github.com/user-attachments/assets/e3d5cacf-e994-4e16-beb7-64c9de282e6d" /><br>
<img width="589" height="289" alt="Capture d’écran 2026-08-17 à 11 49 47" src="https://github.com/user-attachments/assets/af8f5101-c7d6-464c-9afd-4848b1582251" /><br>
<img width="100" height="126" alt="Capture d’écran 2026-08-17 à 11 49 56" src="https://github.com/user-attachments/assets/9a33695c-09ab-4c60-8841-3460e777a6f7" /><br>

Closes #42.

Display on cell vs tooltip for resources and collections is not unified. A larger refactor is warranted, especially to handle enum representation is tooltips.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added my name to [AUTHORS.md](../AUTHORS.md) (alphabetical list)
