### PR TITLE
fix: improve cell text ellipsis performance

### DIFF
--- a/addons/yard/editor_only/classes/data_table/cell_types/cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/cell_type.gd
@@ -32,45 +32,28 @@ static func draw_cell(canvas: CanvasItem, rect: Rect2, value: Variant, column: C
 
 
 static func draw_text(canvas: CanvasItem, rect: Rect2, text: String, font: Font, font_size: int, h_align: HorizontalAlignment, color: Color) -> void:
+	var line := TextLine.new()
 	var x_margin: int = H_ALIGNMENT_MARGINS.get(h_align)
-	var baseline_y := get_text_baseline_y(font, font_size, rect.position.y, rect.size.y)
-	var display_text := get_display_text(text, font, font_size, rect.size.x - absf(x_margin))
-	canvas.draw_string(
-		font,
-		Vector2(rect.position.x + x_margin, baseline_y),
-		display_text,
-		h_align,
-		maxf(0.001, rect.size.x - absf(x_margin)),
-		font_size,
-		color,
-	)
+	var width := rect.size.x - absf(x_margin)
+	var ellipsis_width := font.get_string_size(line.ellipsis_char, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
+
+	if width < ellipsis_width:
+		return
+
+	line.add_string(text, font, font_size)
+	line.width = width
+	line.alignment = h_align
+	line.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS_FORCE
+
+	var line_height := font.get_ascent(font_size) + font.get_descent(font_size)
+	var top_y := rect.position.y + (rect.size.y - line_height) / 2.0
+	line.draw(canvas.get_canvas_item(), Vector2(rect.position.x + x_margin, top_y), color)
 
 
 static func get_text_baseline_y(font: Font, font_size: int, cell_y: float, cell_height: float) -> float:
 	var ascent := font.get_ascent(font_size)
 	var descent := font.get_descent(font_size)
 	return cell_y + (cell_height + ascent - descent) / 2.0
-
-
-static func get_display_text(text: String, font: Font, font_size: int, max_width: float) -> String:
-	var text_size := font.get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size)
-	if text_size.x <= max_width:
-		return text
-
-	var ellipsis := "..."
-	var ellipsis_width := font.get_string_size(ellipsis, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
-	var max_text_width := max_width - ellipsis_width
-	if max_text_width <= 0:
-		return ellipsis
-
-	var truncated_text := ""
-	for i in range(text.length()):
-		var test_text := text.substr(0, i + 1)
-		var test_width := font.get_string_size(test_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
-		if test_width > max_text_width:
-			break
-		truncated_text = test_text
-	return truncated_text + ellipsis
 
 
 static func resolve_font(column: ColumnConfig, fallback_font: Font) -> Font:

--- a/addons/yard/editor_only/classes/data_table/cell_types/range_cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/range_cell_type.gd
@@ -24,7 +24,7 @@ static func draw_cell(canvas: CanvasItem, rect: Rect2, value: Variant, column: C
 
 	var x_margin_val: int = H_ALIGNMENT_MARGINS.get(HORIZONTAL_ALIGNMENT_CENTER)
 	var numeric_text := str(snappedf(cell_value, 0.001))
-	var display_text := get_display_text(numeric_text, style.font, style.font_size, rect.size.x - absf(x_margin_val))
+	var display_text := _get_display_text(numeric_text, style.font, style.font_size, rect.size.x - absf(x_margin_val))
 	var text_width := style.font.get_string_size(display_text, HORIZONTAL_ALIGNMENT_LEFT, -1, style.font_size).x
 	var text_pos := Vector2(rect.position.x + (rect.size.x - text_width) / 2.0, get_text_baseline_y(style.font, style.font_size, rect.position.y, rect.size.y))
 	var fill_width: float = maxf(0.001, fill.position.x + fill.size.x - text_pos.x - absf(x_margin_val) + 5 * scale)
@@ -36,6 +36,27 @@ static func draw_cell(canvas: CanvasItem, rect: Rect2, value: Variant, column: C
 	canvas.draw_string_outline(style.font, text_pos, display_text, HORIZONTAL_ALIGNMENT_LEFT, fill_width, style.font_size, style.font_size / 3, progress_color)
 	canvas.draw_string(style.font, text_pos, display_text, HORIZONTAL_ALIGNMENT_LEFT, fill_width, style.font_size, Color.BLACK)
 	canvas.draw_rect(bar, style.progress_border_color, false, 1.0 * scale)
+
+
+static func _get_display_text(text: String, font: Font, font_size: int, max_width: float) -> String:
+	var text_size := font.get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size)
+	if text_size.x <= max_width:
+		return text
+
+	var ellipsis := "..."
+	var ellipsis_width := font.get_string_size(ellipsis, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
+	var max_text_width := max_width - ellipsis_width
+	if max_text_width <= 0:
+		return ellipsis
+
+	var truncated_text := ""
+	for i in range(text.length()):
+		var test_text := text.substr(0, i + 1)
+		var test_width := font.get_string_size(test_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
+		if test_width > max_text_width:
+			break
+		truncated_text = test_text
+	return truncated_text + ellipsis
 
 
 static func _get_interpolated_three_colors(start_color: Color, mid_color: Color, end_color: Color, progress: float) -> Color:


### PR DESCRIPTION
## Description

The ellipsis calculation for text cells was previously implemented manually with O(N²) complexity, resulting in a noticeable impact on framerate and overall performance with long strings. This PR replaces the manual implementation with Godot's `TextLine` class, which abstracts the underlying `TextServer` functionality.

###  Before/After

<img width="501" height="286" alt="Capture d’écran 2026-08-19 à 13 54 25" src="https://github.com/user-attachments/assets/81bfa48b-a23f-4c38-9e09-c1f1c8537785" />
<img width="501" height="286" alt="Capture d’écran 2026-08-19 à 13 54 55" src="https://github.com/user-attachments/assets/be95235e-d5e3-4538-9b85-59f4f509d9db" />


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added my name to [AUTHORS.md](../AUTHORS.md) (alphabetical list)
