### PR TITLE
fix: prevent error when selecting a color in the color editor

### DIFF
--- a/addons/yard/editor_only/classes/data_table/cell_types/color_cell_type.gd
+++ b/addons/yard/editor_only/classes/data_table/cell_types/color_cell_type.gd
@@ -65,7 +65,10 @@ static func create_editor(owner: Control, rect: Rect2, value: Variant, _column: 
 	owner.add_child(popup)
 	popup.position = rect.get_center() + owner.global_position
 	popup.color = value
-	popup.color_selected.connect(on_finished.bind(true))
+	popup.color_selected.connect(
+		# Discard color value
+		func(_c: Color) -> void: on_finished.call(true)
+	)
 	popup.canceled.connect(on_finished.bind(false))
 	popup.show()
 	popup.grab_focus()


### PR DESCRIPTION
## Description

`ColorPopup.color_selected` passes 2 arguments but `DataTable._on_editor_finished` only accepted 1, causing a crash on color selection. Fixed to match callback signature.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added my name to [AUTHORS.md](../AUTHORS.md) (alphabetical list)
