### PR TITLE
fix: stop row filtering from throwing an error

### DIFF
--- a/addons/yard/editor_only/classes/data_table/data_table.gd
+++ b/addons/yard/editor_only/classes/data_table/data_table.gd
@@ -813,7 +813,7 @@ func _rebuild_filtered_order() -> void:
 	_order.clear()
 	var key_lower := _filter_text.to_lower()
 	for row in _base_order:
-		var row_data: Dictionary[StringName, Dictionary] = _rows.get(row, { })
+		var row_data: Dictionary[StringName, Variant] = _rows.get(row, { })
 		if is_cell_valid(row, _filtered_column):
 			if str(row_data[_filtered_column]).to_lower().contains(key_lower):
 				_order.append(row)


### PR DESCRIPTION
## Description

Filtering a column does not work and throw the following error:
```
ERROR: res://addons/yard/editor_only/classes/data_table/data_table.gd:807 - Trying to assign a dictionary of type "Dictionary[StringName, Nil]" to a variable of type "Dictionary[StringName, Dictionary]".
```

This PR fixes the regression.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added my name to [AUTHORS.md](../AUTHORS.md) (alphabetical list)
