### PR TITLE
feat: strip leading/trailing whitespace from new entry string IDs

### DIFF
--- a/addons/yard/editor_only/registry_io.gd
+++ b/addons/yard/editor_only/registry_io.gd
@@ -102,6 +102,7 @@ static func add_entry(registry: Registry, uid: StringName, string_id: String = "
 	if not ResourceUID.has_id(cache_id):
 		return ERR_CANT_ACQUIRE_RESOURCE
 
+	string_id = string_id.strip_edges()
 	if string_id.begins_with(("uid://")):
 		return ERR_INVALID_PARAMETER
 
@@ -115,9 +116,7 @@ static func add_entry(registry: Registry, uid: StringName, string_id: String = "
 	if not string_id:
 		string_id = ResourceUID.get_id_path(cache_id).get_file().get_basename()
 
-	if string_id in registry._string_ids_to_uids:
-		string_id = _make_string_id_unique(registry, string_id)
-
+	string_id = _make_string_id_unique(registry, string_id)
 	registry._uids_to_string_ids[uid] = string_id as StringName
 	registry._string_ids_to_uids[string_id] = uid
 
@@ -179,7 +178,7 @@ static func rename_entry(
 		return ERR_INVALID_PARAMETER
 
 	registry._string_ids_to_uids.erase(id)
-	var unique_new_string_id := _make_string_id_unique(registry, new_string_id)
+	var unique_new_string_id := _make_string_id_unique(registry, new_string_id.strip_edges())
 	registry._string_ids_to_uids[unique_new_string_id] = uid
 	registry._uids_to_string_ids[uid] = unique_new_string_id
 	return ResourceSaver.save(registry)

--- a/addons/yard/editor_only/ui_scenes/registry_table_view.gd
+++ b/addons/yard/editor_only/ui_scenes/registry_table_view.gd
@@ -554,11 +554,12 @@ func _setup_add_entry() -> void:
 	entry_name_line_edit.text = ""
 
 
-func _add_entry_from_picker(res: Resource, string_id: StringName) -> void:
+func _add_entry_from_picker(res: Resource, string_id: String) -> void:
 	var res_is_file := res.resource_path and ResourceLoader.exists(res.resource_path)
+	string_id = string_id.strip_edges()
 	if not res_is_file:
 		var current_dir := EditorInterface.get_current_path().get_base_dir()
-		var save_path := current_dir.path_join(str(string_id) + ".tres")
+		var save_path := current_dir.path_join(string_id + ".tres")
 		if ResourceLoader.exists(save_path):
 			YardLogger.error("A file already exists at '%s'. Choose a different String ID or save the resource manually first." % save_path)
 			return
@@ -751,4 +752,4 @@ func _on_add_entry_button_pressed() -> void:
 	if add_entry_button.disabled:
 		return
 
-	_add_entry_from_picker(_res_picker.edited_resource, StringName(entry_name_line_edit.text))
+	_add_entry_from_picker(_res_picker.edited_resource, entry_name_line_edit.text)


### PR DESCRIPTION
## Description

Entry string IDs are now trimmed of leading/trailing whitespace both when adding via the bottom entry bar and when editing the String ID column in the table.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added my name to [AUTHORS.md](../AUTHORS.md) (alphabetical list)
